### PR TITLE
Add Rubocop

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,5 @@
+version: "2"
+plugins:
+  rubocop:
+    enabled: true
+    channel: rubocop-0-67

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,1 @@
+require: rubocop-performance

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,5 @@
 require: rubocop-performance
+
+Metrics/LineLength:
+  Description: 'Limit lines to 120 characters.'
+  Max: 120

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require: rubocop-performance
+# require: rubocop-performance
 
 Metrics/LineLength:
   Description: 'Limit lines to 120 characters.'

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,10 @@ group :development, :test do
   gem 'simplecov'
   gem 'factory_bot', '~> 5.1'
   gem 'factory_bot_rails', '~> 5.1'
+  gem 'rubocop', require: false
+  gem 'rubocop-performance'
+  gem 'rubocop-rails'
+  gem 'rubocop-rspec'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
+    ast (2.4.0)
     bindex (0.8.1)
     bootsnap (1.4.4)
       msgpack (~> 1.0)
@@ -75,6 +76,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
+    jaro_winkler (1.5.3)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
     json (2.2.0)
@@ -98,6 +100,9 @@ GEM
     nio4r (2.4.0)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
+    parallel (1.18.0)
+    parser (2.6.5.0)
+      ast (~> 2.4.0)
     pg (1.1.4)
     public_suffix (3.1.1)
     puma (3.12.1)
@@ -130,6 +135,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
+    rainbow (3.0.0)
     rake (12.3.3)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
@@ -156,6 +162,21 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
+    rubocop (0.75.1)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.6)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-performance (1.5.0)
+      rubocop (>= 0.71.0)
+    rubocop-rails (2.3.2)
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
+    rubocop-rspec (1.36.0)
+      rubocop (>= 0.68.1)
+    ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     rubyzip (1.3.0)
     sass (3.7.4)
@@ -198,6 +219,7 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    unicode-display_width (1.6.0)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -233,6 +255,10 @@ DEPENDENCIES
   rails (~> 5.2)
   rspec
   rspec-rails (~> 3.8)
+  rubocop
+  rubocop-performance
+  rubocop-rails
+  rubocop-rspec
   sass-rails (~> 5)
   seedbank
   selenium-webdriver

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
   end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
 end

--- a/app/controllers/hunters_controller.rb
+++ b/app/controllers/hunters_controller.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
+# Restful Hunters Controller
 class HuntersController < ApplicationController
-  before_action :set_hunter, only: [:show, :edit, :update, :destroy]
+  before_action :set_hunter, only: %i[show edit update destroy]
 
   # GET /hunters
   # GET /hunters.json
@@ -9,8 +12,7 @@ class HuntersController < ApplicationController
 
   # GET /hunters/1
   # GET /hunters/1.json
-  def show
-  end
+  def show() end
 
   # GET /hunters/new
   def new
@@ -18,8 +20,7 @@ class HuntersController < ApplicationController
   end
 
   # GET /hunters/1/edit
-  def edit
-  end
+  def edit() end
 
   # POST /hunters
   # POST /hunters.json
@@ -62,13 +63,15 @@ class HuntersController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_hunter
-      @hunter = Hunter.find(params[:id])
-    end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
-    def hunter_params
-      params.require(:hunter).permit(:name, :playbook_id, :harm, :luck, :experience, :charm, :cool, :sharp, :tough, :weird)
-    end
+  # Use callbacks to share common setup or constraints between actions.
+  def set_hunter
+    @hunter = Hunter.find(params[:id])
+  end
+
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def hunter_params
+    params.require(:hunter)
+          .permit(:name, :playbook_id, :harm, :luck, :experience, :charm, :cool, :sharp, :tough, :weird)
+  end
 end

--- a/app/controllers/moves_controller.rb
+++ b/app/controllers/moves_controller.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
+# Restful controller for Moves
 class MovesController < ApplicationController
-  before_action :set_move, only: [:show, :edit, :update, :destroy]
+  before_action :set_move, only: %i[show edit update destroy]
 
   # GET /moves
   # GET /moves.json
@@ -9,8 +12,7 @@ class MovesController < ApplicationController
 
   # GET /moves/1
   # GET /moves/1.json
-  def show
-  end
+  def show() end
 
   # GET /moves/new
   def new
@@ -18,8 +20,7 @@ class MovesController < ApplicationController
   end
 
   # GET /moves/1/edit
-  def edit
-  end
+  def edit() end
 
   # POST /moves
   # POST /moves.json
@@ -62,13 +63,14 @@ class MovesController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_move
-      @move = Move.find(params[:id])
-    end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
-    def move_params
-      params.require(:move).permit(:type, :name, :rating, :six_and_under, :seven_to_nine, :ten_plus, :twelve_plus)
-    end
+  # Use callbacks to share common setup or constraints between actions.
+  def set_move
+    @move = Move.find(params[:id])
+  end
+
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def move_params
+    params.require(:move).permit(:type, :name, :rating, :six_and_under, :seven_to_nine, :ten_plus, :twelve_plus)
+  end
 end

--- a/app/controllers/playbooks_controller.rb
+++ b/app/controllers/playbooks_controller.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
+# Restful controller for Playbooks
 class PlaybooksController < ApplicationController
-  before_action :set_playbook, only: [:show, :edit, :update, :destroy]
+  before_action :set_playbook, only: %i[show edit update destroy]
 
   # GET /playbooks
   # GET /playbooks.json
@@ -9,8 +12,7 @@ class PlaybooksController < ApplicationController
 
   # GET /playbooks/1
   # GET /playbooks/1.json
-  def show
-  end
+  def show() end
 
   # GET /playbooks/new
   def new
@@ -18,8 +20,7 @@ class PlaybooksController < ApplicationController
   end
 
   # GET /playbooks/1/edit
-  def edit
-  end
+  def edit() end
 
   # POST /playbooks
   # POST /playbooks.json
@@ -62,13 +63,14 @@ class PlaybooksController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_playbook
-      @playbook = Playbook.find(params[:id])
-    end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
-    def playbook_params
-      params.require(:playbook).permit(:name, :description)
-    end
+  # Use callbacks to share common setup or constraints between actions.
+  def set_playbook
+    @playbook = Playbook.find(params[:id])
+  end
+
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def playbook_params
+    params.require(:playbook).permit(:name, :description)
+  end
 end

--- a/app/controllers/ratings_controller.rb
+++ b/app/controllers/ratings_controller.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
+# Restful controller for Ratings
 class RatingsController < ApplicationController
-  before_action :set_rating, only: [:show, :edit, :update, :destroy]
+  before_action :set_rating, only: %i[show edit update destroy]
 
   # GET /ratings
   # GET /ratings.json
@@ -9,8 +12,7 @@ class RatingsController < ApplicationController
 
   # GET /ratings/1
   # GET /ratings/1.json
-  def show
-  end
+  def show() end
 
   # GET /ratings/new
   def new
@@ -18,8 +20,7 @@ class RatingsController < ApplicationController
   end
 
   # GET /ratings/1/edit
-  def edit
-  end
+  def edit() end
 
   # POST /ratings
   # POST /ratings.json
@@ -62,13 +63,14 @@ class RatingsController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_rating
-      @rating = Rating.find(params[:id])
-    end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
-    def rating_params
-      params.require(:rating).permit(:playbook_id, :charm, :cool, :sharp, :tough, :weird)
-    end
+  # Use callbacks to share common setup or constraints between actions.
+  def set_rating
+    @rating = Rating.find(params[:id])
+  end
+
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def rating_params
+    params.require(:rating).permit(:playbook_id, :charm, :cool, :sharp, :tough, :weird)
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
+# frozen_string_literal: true
+
+# Application Helper
 module ApplicationHelper
 end

--- a/app/helpers/hunters_helper.rb
+++ b/app/helpers/hunters_helper.rb
@@ -1,2 +1,5 @@
+# frozen_string_literal: true
+
+# Hunters Helper
 module HuntersHelper
 end

--- a/app/helpers/moves_helper.rb
+++ b/app/helpers/moves_helper.rb
@@ -1,2 +1,5 @@
+# frozen_string_literal: true
+
+# Moves Helper
 module MovesHelper
 end

--- a/app/helpers/playbooks_helper.rb
+++ b/app/helpers/playbooks_helper.rb
@@ -1,2 +1,5 @@
+# frozen_string_literal: true
+
+# Playbooks Helper
 module PlaybooksHelper
 end

--- a/app/helpers/ratings_helper.rb
+++ b/app/helpers/ratings_helper.rb
@@ -1,2 +1,5 @@
+# frozen_string_literal: true
+
+# Ratings Helper
 module RatingsHelper
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationJob < ActiveJob::Base
   # Automatically retry jobs that encountered a deadlock
   # retry_on ActiveRecord::Deadlocked

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# Base Mailer
 class ApplicationMailer < ActionMailer::Base
   default from: 'from@example.com'
   layout 'mailer'

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# This is Application Record. . .
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end

--- a/app/models/hunter.rb
+++ b/app/models/hunter.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# The character appearing in the mystery
 class Hunter < ApplicationRecord
   belongs_to :playbook
   validates :harm, numericality: { less_than_or_equal_to: 7, greater_than_or_equal_to: 0 }

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
+# Actions that the hunters can take
 class Move < ApplicationRecord
-  MOVE_TYPES = %w[Moves::Basic]
+  MOVE_TYPES = %w[Moves::Basic].freeze
 
   validates :type, inclusion: { in: MOVE_TYPES }
 
@@ -9,19 +12,19 @@ class Move < ApplicationRecord
     Random.new.rand(2..12) + hunter.send(rating)
   end
 
-  def roll_results(hunter)
+  def roll_results(hunter) # rubocop:disable Metrics/MethodLength
     result = roll(hunter)
     outcome = case result
-    when 0..6
-      six_and_under
-    when 7..9
-      seven_to_nine
-    when 10..11
-      ten_plus
-    else
-      # TODO: Add advanced Moves logic
-      ten_plus
-    end
+              when 0..6
+                six_and_under
+              when 7..9
+                seven_to_nine
+              when 10..11
+                ten_plus
+              else
+                # TODO: Add advanced Moves logic
+                ten_plus
+              end
     "Your total #{result} resulted in #{outcome}"
   end
 end

--- a/app/models/moves/basic.rb
+++ b/app/models/moves/basic.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Moves
   class Basic < Move
   end

--- a/app/models/playbook.rb
+++ b/app/models/playbook.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+# The class or playbook that the hunter has
+# provides unique abilities to the Hunter
 class Playbook < ApplicationRecord
-  has_many :ratings 
+  has_many :ratings
 end

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+# The ratings/attributes that the Hunter has
+# determines their capability to do something
 class Rating < ApplicationRecord
   belongs_to :playbook
 end

--- a/app/views/hunters/_hunter.json.jbuilder
+++ b/app/views/hunters/_hunter.json.jbuilder
@@ -1,2 +1,15 @@
-json.extract! hunter, :id, :name, :harm, :luck, :experience, :charm, :cool, :sharp, :tough, :weird, :created_at, :updated_at
+# frozen_string_literal: true
+
+json.extract! hunter, :id,
+              :name,
+              :harm,
+              :luck,
+              :experience,
+              :charm,
+              :cool,
+              :sharp,
+              :tough,
+              :weird,
+              :created_at,
+              :updated_at
 json.url hunter_url(hunter, format: :json)

--- a/app/views/hunters/index.json.jbuilder
+++ b/app/views/hunters/index.json.jbuilder
@@ -1,1 +1,3 @@
-json.array! @hunters, partial: "hunters/hunter", as: :hunter
+# frozen_string_literal: true
+
+json.array! @hunters, partial: 'hunters/hunter', as: :hunter

--- a/app/views/hunters/show.json.jbuilder
+++ b/app/views/hunters/show.json.jbuilder
@@ -1,1 +1,3 @@
-json.partial! "hunters/hunter", hunter: @hunter
+# frozen_string_literal: true
+
+json.partial! 'hunters/hunter', hunter: @hunter

--- a/app/views/moves/_move.json.jbuilder
+++ b/app/views/moves/_move.json.jbuilder
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 json.extract! move, :id,
-                    :name,
-                    :rating,
-                    :six_and_under,
-                    :seven_to_nine,
-                    :ten_plus,
-                    :twelve_plus,
-                    :created_at,
-                    :updated_at
+              :name,
+              :rating,
+              :six_and_under,
+              :seven_to_nine,
+              :ten_plus,
+              :twelve_plus,
+              :created_at,
+              :updated_at
 json.url move_url(move, format: :json)

--- a/app/views/moves/index.json.jbuilder
+++ b/app/views/moves/index.json.jbuilder
@@ -1,1 +1,3 @@
-json.array! @moves, partial: "moves/move", as: :move
+# frozen_string_literal: true
+
+json.array! @moves, partial: 'moves/move', as: :move

--- a/app/views/moves/show.json.jbuilder
+++ b/app/views/moves/show.json.jbuilder
@@ -1,1 +1,3 @@
-json.partial! "moves/move", move: @move
+# frozen_string_literal: true
+
+json.partial! 'moves/move', move: @move

--- a/app/views/playbooks/_playbook.json.jbuilder
+++ b/app/views/playbooks/_playbook.json.jbuilder
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 json.extract! playbook, :id, :name, :description, :created_at, :updated_at
 json.url playbook_url(playbook, format: :json)

--- a/app/views/playbooks/index.json.jbuilder
+++ b/app/views/playbooks/index.json.jbuilder
@@ -1,1 +1,3 @@
-json.array! @playbooks, partial: "playbooks/playbook", as: :playbook
+# frozen_string_literal: true
+
+json.array! @playbooks, partial: 'playbooks/playbook', as: :playbook

--- a/app/views/playbooks/show.json.jbuilder
+++ b/app/views/playbooks/show.json.jbuilder
@@ -1,1 +1,3 @@
-json.partial! "playbooks/playbook", playbook: @playbook
+# frozen_string_literal: true
+
+json.partial! 'playbooks/playbook', playbook: @playbook

--- a/app/views/ratings/_rating.json.jbuilder
+++ b/app/views/ratings/_rating.json.jbuilder
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 json.extract! rating, :id, :playbook_id, :charm, :cool, :sharp, :tough, :weird, :created_at, :updated_at
 json.url rating_url(rating, format: :json)

--- a/app/views/ratings/index.json.jbuilder
+++ b/app/views/ratings/index.json.jbuilder
@@ -1,1 +1,3 @@
-json.array! @ratings, partial: "ratings/rating", as: :rating
+# frozen_string_literal: true
+
+json.array! @ratings, partial: 'ratings/rating', as: :rating

--- a/app/views/ratings/show.json.jbuilder
+++ b/app/views/ratings/show.json.jbuilder
@@ -1,1 +1,3 @@
-json.partial! "ratings/rating", rating: @rating
+# frozen_string_literal: true
+
+json.partial! 'ratings/rating', rating: @rating


### PR DESCRIPTION
closes #4 

Rubocop keeps styles consistent across the codebase. The sooner it's added, the less clean up we'll have to do later.
https://docs.rubocop.org/en/stable/
- [x] [Rubocop](https://github.com/rubocop-hq/rubocop) - `gem 'rubocop', require: false`
- [x] [Rubocop for Rspec](https://github.com/rubocop-hq/rubocop-rspec) `gem 'rubocop-rspec'`
- [x] [Rubocop for Rails](https://github.com/rubocop-hq/rubocop-rails) - `gem 'rubocop-rails'`
- [x] [Performance Cops](https://github.com/rubocop-hq/rubocop-performance) - `gem 'rubocop-performance'`

All existing issues in the codebase have been fixed.