### PR TITLE
Exclude Schema from Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,7 @@
 # require: rubocop-performance
+AllCops:
+  Excludes:
+    - db/schema.rb
 
 Metrics/LineLength:
   Description: 'Limit lines to 120 characters.'


### PR DESCRIPTION
### Problem
Rubocop likes to replace all the doublequotes in db/schema.rb with single quotes and add the magic comment `# frozen_string_literal: true` but db/schema.rb is autocreated by rails, so these changes are removed every time someone changes the database in some way. This results in a large amount of code churn, and is largely pointless.

### Solution
Exclude db/schema.rb from all Rubocop checks and autocorrection.