### PR TITLE
Add Chosen Moves Seedfile

### DIFF
--- a/app/helpers/playbooks_helper.rb
+++ b/app/helpers/playbooks_helper.rb
@@ -2,4 +2,7 @@
 
 # Playbooks Helper
 module PlaybooksHelper
+  def link_to_playbook(obj)
+    obj.playbook ? link_to(obj.playbook.name, obj.playbook) : ''
+  end
 end

--- a/app/views/hunters/index.html.erb
+++ b/app/views/hunters/index.html.erb
@@ -4,6 +4,7 @@
   <thead>
     <tr>
       <th>Name</th>
+      <th>Playbook</th>
       <th>Harm</th>
       <th>Luck</th>
       <th>Experience</th>
@@ -20,6 +21,7 @@
     <% @hunters.each do |hunter| %>
       <tr>
         <td><%= hunter.name %></td>
+        <td><%= link_to_playbook(hunter) %></td>
         <td><%= hunter.harm %></td>
         <td><%= hunter.luck %></td>
         <td><%= hunter.experience %></td>

--- a/app/views/moves/index.html.erb
+++ b/app/views/moves/index.html.erb
@@ -3,6 +3,7 @@
 <table>
   <thead>
     <tr>
+      <th>Playbook</th>
       <th>Name</th>
       <th>Rating</th>
       <th colspan="3"></th>
@@ -12,6 +13,7 @@
   <tbody>
     <% @moves.each do |move| %>
       <tr>
+        <td><%= link_to_playbook(move) %></td>
         <td><%= move.name %></td>
         <td><%= move.rating %></td>
         <td><%= link_to 'Show', move_path(move) %></td>

--- a/db/seeds/move.seeds.rb
+++ b/db/seeds/move.seeds.rb
@@ -251,12 +251,10 @@ poison.'
   Moves::Basic.find_or_create_by(move)
 end
 
-# ,
-# {
-#  name: '',
-#  rating:
-#  six_and_under:
-#   seven_to_nine:
-#   ten_plus:
-#   twelve_plus:
-# }
+######
+# Playbook Moves
+######
+
+######
+# Chosen
+######

--- a/db/seeds/move.seeds.rb
+++ b/db/seeds/move.seeds.rb
@@ -251,10 +251,89 @@ poison.'
   Moves::Basic.find_or_create_by(move)
 end
 
-######
-# Playbook Moves
-######
+after :playbook do
+  ######
+  # Playbook Moves
+  # ratings: charm: 0, cool: 1, sharp: 2, tough: 3, weird: 4
+  ######
 
-######
-# Chosen
-######
+  ######
+  # Chosen
+  ######
+  chosen = Playbook.find 1
+  [{
+    name: "Destiny's Plaything",
+    rating: :weird,
+    six_and_under: 'On a miss, something bad is going to happen to you.',
+    seven_to_nine: 'On
+  a 7-9 you get a vague hint about the coming mystery.',
+    ten_plus: "On a 10+, the Keeper will
+  reveal a useful detail about the coming mystery.",
+    type: 'Moves::Rollable',
+    playbook_id: chosen.id,
+    description: 'At the beginning of each
+  mystery, roll +Weird to see what is revealed about
+  your immediate future.'
+  },
+   {
+     name: 'I’m Here For A Reason',
+     type: 'Moves::Descriptive',
+     playbook_id: chosen.id,
+     description: 'There’s something you are
+  destined to do. Work out the details with the Keeper,
+  based on your fate. You cannot die until it comes
+  to pass. If you die in play, then you must spend a
+  Luck point. You will then, somehow, recover or be
+  returned to life. Once your task is done (or you use
+  up all your Luck), all bets are off.'
+   },
+   {
+     name: 'The Big Entrance',
+     rating: :cool,
+     six_and_under: 'On a miss, you’re marked as the
+  biggest threat by all enemies who are present.',
+     seven_to_nine: 'On a 7-9, you pick one
+  person or monster to stop, watch and listen until
+  you finish talking.',
+     ten_plus: 'On 10+ everyone stops to watch and listen until you
+  finish your opening speech.',
+     type: 'Moves::Rollable',
+     playbook_id: chosen.id,
+     description: 'When you make a showy
+  entrance into a dangerous situation, roll +Cool.'
+   },
+   {
+     name: 'Devastating',
+     type: 'Moves::Descriptive',
+     playbook_id: chosen.id,
+     description: 'When you inflict harm, you may
+  inflict +1 harm.'
+   },
+   {
+     name: 'Dutiful',
+     type: 'Moves::Descriptive',
+     playbook_id: chosen.id,
+     description: 'When your fate rears its ugly head, and
+  you act in accordance with any of your fate tags
+  (either heroic or doom) then mark experience. If it’s
+  a heroic tag, take +1 forward'
+   },
+   {
+     name: 'Invincible',
+     type: 'Moves::Descriptive',
+     playbook_id: chosen.id,
+     description: 'You always count as having 2-armour.
+  This doesn’t stack with other protection.'
+   },
+   {
+     name: 'Resilience',
+     type: 'Moves::Descriptive',
+     playbook_id: chosen.id,
+     description: 'You heal faster than normal people. Any
+  time your harm gets healed, heal an extra point.
+  Additionally, your wounds count as 1-harm less for
+  the purpose of the Keeper’s harm moves.'
+   }].each do |move|
+    Move.find_or_create_by(move)
+  end
+end


### PR DESCRIPTION
### Problem
- We don't load the Playbook Moves currently.
- There's a lot of duplicated code for adding a Playbook column to a table.

### Solution
Add a seedfile to load all Chosen moves into the application.
Add a helper to PlaybooksHelper to make displaying playbooks easier.