### PR TITLE
UX Improvements for Hunter Improvements

### DIFF
--- a/app/controllers/hunters_improvements_controller.rb
+++ b/app/controllers/hunters_improvements_controller.rb
@@ -93,7 +93,8 @@ class HuntersImprovementsController < ApplicationController
   end
 
   def set_improvements
-    @improvements = @hunter ? @hunter.playbook.improvements : Improvement.all
+    return @improvements = Improvement.all unless @hunter
+    @improvements = @hunter.available_improvements
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/improvements_controller.rb
+++ b/app/controllers/improvements_controller.rb
@@ -29,7 +29,7 @@ class ImprovementsController < ApplicationController
 
     respond_to do |format|
       if @improvement.save
-        format.html { redirect_to @improvement, notice: 'Improvement was successfully created.' }
+        format.html { redirect_to improvement_url(@improvement), notice: 'Improvement was successfully created.' }
         format.json { render :show, status: :created, location: @improvement }
       else
         format.html { render :new }

--- a/app/models/hunter.rb
+++ b/app/models/hunter.rb
@@ -17,4 +17,8 @@ class Hunter < ApplicationRecord
     Move.where(id: moves.select(:id))
         .or(Move.where(type: 'Moves::Basic'))
   end
+
+  def available_improvements
+    playbook.improvements.where.not(id: improvements.select(:id))
+  end
 end

--- a/app/models/improvement.rb
+++ b/app/models/improvement.rb
@@ -6,6 +6,8 @@
 class Improvement < ApplicationRecord
   IMPROVEMENT_TYPES = %w[Improvement Improvements::RatingBoost].freeze
 
+  belongs_to :playbook
+
   enum rating: { charm: 0, cool: 1, sharp: 2, tough: 3, weird: 4 }
 
   validates :description, presence: true

--- a/app/models/improvements/rating_boost.rb
+++ b/app/models/improvements/rating_boost.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# frozen_string_literal: true.
-
 module Improvements
   # This is for Improvements like "Get +1 Weird, max +3"
   class RatingBoost < Improvement

--- a/app/views/hunters_improvements/index.html.erb
+++ b/app/views/hunters_improvements/index.html.erb
@@ -2,13 +2,11 @@
 
 <h1>Hunters Improvements</h1>
 
-<table>
+<table class='bp3-html-table'>
   <thead>
-    <tr>Hunter</tr>
-    <tr>Improvement</tr>
-    <tr>
-      <th colspan="3"></th>
-    </tr>
+    <th>Hunter</th>
+    <th>Improvement</th>
+    <th colspan="3"></th>
   </thead>
 
   <tbody>

--- a/app/views/improvements/index.html.erb
+++ b/app/views/improvements/index.html.erb
@@ -5,6 +5,7 @@
 <table>
   <thead>
     <tr>
+      <th>Playbook</th>
       <th>Description</th>
       <th>Rating</th>
       <th>Stat limit</th>
@@ -15,6 +16,7 @@
   <tbody>
     <% @improvements.each do |improvement| %>
       <tr>
+        <td><%= link_to_playbook(improvement) %>
         <td><%= link_to improvement.description, improvement_path(improvement) %></td>
         <td><%= improvement.rating %></td>
         <td><%= improvement.stat_limit %></td>

--- a/spec/controllers/improvements_controller_spec.rb
+++ b/spec/controllers/improvements_controller_spec.rb
@@ -84,6 +84,16 @@ RSpec.describe ImprovementsController, type: :controller do
           subject
           expect(response).to redirect_to(Improvement.last)
         end
+
+        context 'with a rating boost improvement' do
+          let(:attributes) { { description: 'Get +1 Tough, max +3', type: 'Improvements::RatingBoost' } }
+
+          it 'redirects to created improvement' do
+            subject
+            expect(Improvement.last.class).to eq Improvements::RatingBoost
+            expect(response).to redirect_to(improvement_url(Improvement.last))
+          end
+        end
       end
 
       context 'json format' do

--- a/spec/controllers/improvements_controller_spec.rb
+++ b/spec/controllers/improvements_controller_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe ImprovementsController, type: :controller do
   # adjust the attributes here as well.
   let(:valid_attributes) do
     {
-      description: 'Gain an Ally'
+      description: 'Gain an Ally',
+      playbook_id: create(:playbook).id
     }
   end
 
@@ -86,7 +87,7 @@ RSpec.describe ImprovementsController, type: :controller do
         end
 
         context 'with a rating boost improvement' do
-          let(:attributes) { { description: 'Get +1 Tough, max +3', type: 'Improvements::RatingBoost' } }
+          let(:attributes) { { description: 'Get +1 Tough, max +3', type: 'Improvements::RatingBoost', playbook_id: create(:playbook).id } }
 
           it 'redirects to created improvement' do
             subject

--- a/spec/factories/improvements.rb
+++ b/spec/factories/improvements.rb
@@ -2,11 +2,13 @@
 
 FactoryBot.define do
   factory :improvement do
+    playbook
     description { 'Gain an Ally' }
     type { nil }
   end
 
   factory :rating_boost, class: Improvements::RatingBoost do
+    playbook
     description { 'Get +1 Charm, max +3' }
     type { 'Improvements::RatingBoost' }
     rating { 0 } # Charm

--- a/spec/models/hunter_spec.rb
+++ b/spec/models/hunter_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Hunter, type: :model do
+  let(:hunter) { create(:hunter) }
+
+  describe '#available_improvements' do
+    subject { hunter.available_improvements }
+
+    context 'improvement outside playbook' do
+      let!(:improvement) { create :improvement, playbook: create(:playbook) }
+
+      it { is_expected.not_to include(:improvement) }
+    end
+
+    context 'improvement matches hunter playbook' do
+      let!(:improvement) { create(:improvement, playbook: hunter.playbook) }
+
+      it { is_expected.to include(improvement) }
+      context 'hunter already has improvement' do
+        let!(:hunters_improvement) { create(:hunters_improvement, hunter: hunter, improvement: improvement) }
+
+        it { is_expected.not_to include(:improvement) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Issue
Improvements has a few rough corners that could be _improved_.
- Creating a RatingBoost Improvement doesn't redirect to the show page
- Can't see Playbook on improvements
- HuntersImprovements#new and HuntersImprovements#edit shows all applicable improvements, but the hunter could have already taken those improvements
- HuntersImprovement table looks wonky

### Solution
- explicitly list url in ImprovementsController to handle single-table inheritance records
- Show Playbook on Improvements using new `link_to_playbook` method in PlaybookHelper
- Add `available_improvements` to hunter.rb that excludes moves the hunter has already taken, and use that method to populate improvements
- Use html classes from [blueprint](https://blueprintjs.com/docs/#core/components/html-table) and remove unnecessary `<tr>`'s.