### PR TITLE
Automatically run Migrations on Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+release: rake db:migrate


### PR DESCRIPTION
closes #35 
### Issue
When we migrate our changes from master to Heroku and deploy them, we need to manually run `rake db:migrate`. This command can be forgotten, and result in down-time for the application. Even in a best case scenario, the application will deploy, and have a moment's downtime or frustrating experience while we run `rake db:migrate`.

### Solution
Add Procfile and release phase to heroku