### PR TITLE
Add Hunter rating Component

### DIFF
--- a/app/controllers/moves_controller.rb
+++ b/app/controllers/moves_controller.rb
@@ -7,11 +7,7 @@ class MovesController < ApplicationController
   # GET /moves
   # GET /moves.json
   def index
-    if params[:basic]
-      @moves = Moves::Basic.all
-    else
-      @moves = Move.all
-    end
+    @moves = params[:basic] ? Moves::Basic.all : Move.all
   end
 
   # GET /moves/1

--- a/app/models/hunter.rb
+++ b/app/models/hunter.rb
@@ -14,12 +14,12 @@ class Hunter < ApplicationRecord
   validates :harm, numericality: { less_than_or_equal_to: 7, greater_than_or_equal_to: 0 }
   validates :luck, numericality: { less_than_or_equal_to: 7, greater_than_or_equal_to: 0 }
 
-  def hunter_moves
-    Move.where(id: moves.select(:id))
-        .or(Move.where(type: 'Moves::Basic'))
-  end
-
   def available_improvements
     playbook.improvements.where.not(id: improvements.select(:id))
+  end
+
+  def gain_experience(exp)
+    self.experience += exp
+    save
   end
 end

--- a/app/models/hunters_improvement.rb
+++ b/app/models/hunters_improvement.rb
@@ -13,6 +13,7 @@ class HuntersImprovement < ApplicationRecord
   def apply_improvement
     if improvement.valid_hunter? hunter
       improvement.apply hunter
+      hunter.gain_experience(-5)
     else
       add_errors_from_improvement
       raise ActiveRecord::RecordInvalid

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -22,6 +22,7 @@ class Move < ApplicationRecord
     result = roll(hunter)
     outcome = case result
               when 0..6
+                hunter.gain_experience(1)
                 six_and_under
               when 7..9
                 seven_to_nine

--- a/app/views/hunters/index.html.erb
+++ b/app/views/hunters/index.html.erb
@@ -13,7 +13,7 @@
       <th>Sharp</th>
       <th>Tough</th>
       <th>Weird</th>
-      <th colspan="3"></th>
+      <th colspan="2"></th>
     </tr>
   </thead>
 

--- a/app/views/hunters/index.html.erb
+++ b/app/views/hunters/index.html.erb
@@ -20,7 +20,7 @@
   <tbody>
     <% @hunters.each do |hunter| %>
       <tr>
-        <td><%= hunter.name %></td>
+        <td><%= link_to hunter.name, hunter %></td>
         <td><%= link_to_playbook(hunter) %></td>
         <td><%= hunter.harm %></td>
         <td><%= hunter.luck %></td>
@@ -30,7 +30,6 @@
         <td><%= hunter.sharp %></td>
         <td><%= hunter.tough %></td>
         <td><%= hunter.weird %></td>
-        <td><%= link_to 'Show', hunter %></td>
         <td><%= link_to 'Edit', edit_hunter_path(hunter) %></td>
         <td><%= link_to 'Destroy', hunter, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>

--- a/app/views/hunters/show.html.erb
+++ b/app/views/hunters/show.html.erb
@@ -17,17 +17,18 @@
     <p>
       <strong>Experience:</strong>
       <%= @hunter.experience %>
+      <span v-if="<%= @hunter.experience %> >= 5">
+        <%= link_to 'Take an Improvement', new_hunter_hunters_improvement_path(hunter_id: @hunter.id) %>
+      </span>
     </p>
   </div>
   <div class="column">
     <p>
       <h4>Moves</h4>
-      <%= render "moves/moves", moves: @hunter.hunter_moves, hunter: @hunter %>
+      <%= render "moves/moves", moves: @hunter.moves, hunter: @hunter %>
     </p>
   </div>
 </div>
-
-<%= link_to 'Take an Improvement', new_hunter_hunters_improvement_path(hunter_id: @hunter.id) %>
 <br />
 <%= link_to 'Edit', edit_hunter_path(@hunter) %> |
 <%= link_to 'Back', hunters_path %>

--- a/spec/factories/hunters.rb
+++ b/spec/factories/hunters.rb
@@ -10,5 +10,6 @@ FactoryBot.define do
     sharp { 1 }
     tough { 1 }
     weird { -1 }
+    experience { 0 }
   end
 end

--- a/spec/models/hunter_spec.rb
+++ b/spec/models/hunter_spec.rb
@@ -23,4 +23,14 @@ RSpec.describe Hunter, type: :model do
       end
     end
   end
+
+  describe '#gain_experience' do
+    subject { hunter.gain_experience(exp) }
+
+    let(:exp) { 1 }
+    it 'increases the hunter experience' do
+      expect { subject }.to change(hunter.reload, :experience).by(1)
+      expect(hunter.reload.experience).to eq 1
+    end
+  end
 end

--- a/spec/models/hunters_improvement_spec.rb
+++ b/spec/models/hunters_improvement_spec.rb
@@ -73,6 +73,10 @@ RSpec.describe HuntersImprovement, type: :model do
       it 'boosts the stat of the hunter' do
         expect { subject }.to change(hunters_improvement.hunter.reload, :charm).by(1)
       end
+
+      it 'costs 5 experience to take an improvement' do
+        expect { subject }.to change(hunter, :experience).by(-5)
+      end
     end
 
     context 'invalid hunter' do


### PR DESCRIPTION
Add a Beautiful new Hunter Ratings component that shows ratings and allows the hunter to roll basic moves.
![image](https://user-images.githubusercontent.com/8124558/71325795-fd956000-24bf-11ea-884a-61d07ce6b533.png)

Update experience when failing a roll or taking an improvement.
