### PR TITLE
Change Improvable to support Improvements

### DIFF
--- a/app/controllers/hunters_improvements_controller.rb
+++ b/app/controllers/hunters_improvements_controller.rb
@@ -30,7 +30,7 @@ class HuntersImprovementsController < ApplicationController
   def create
     @hunters_improvement = HuntersImprovement.new(hunters_improvement_params)
     @hunters_improvement.hunter = @hunter
-    update_improveable_option
+    update_improvable_option
 
     respond_to do |format|
       if @hunters_improvement.save
@@ -54,7 +54,7 @@ class HuntersImprovementsController < ApplicationController
   # PATCH/PUT /hunters_improvements/1.json
   def update
     respond_to do |format|
-      update_improveable_option
+      update_improvable_option
       if @hunters_improvement.update(hunters_improvement_params)
         format.html do
           redirect_to hunter_hunters_improvement_url(hunter_id: @hunter.id, id: @hunters_improvement.id),
@@ -100,15 +100,15 @@ class HuntersImprovementsController < ApplicationController
     @improvements = @hunter.available_improvements
   end
 
-  def update_improveable_option
-    return unless @hunters_improvement.improveable
-    raw = JSON.parse(@hunters_improvement.improveable)
-    @hunters_improvement.improveable = raw
+  def update_improvable_option
+    return unless @hunters_improvement.improvable
+    raw = JSON.parse(@hunters_improvement.improvable)
+    @hunters_improvement.improvable = raw
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def hunters_improvement_params
     params.require(:hunters_improvement)
-          .permit(:hunter_id, :improvement_id, :improvable_id, :improvable_type, :improveable)
+          .permit(:hunter_id, :improvement_id, :improvable)
   end
 end

--- a/app/controllers/hunters_improvements_controller.rb
+++ b/app/controllers/hunters_improvements_controller.rb
@@ -108,6 +108,7 @@ class HuntersImprovementsController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def hunters_improvement_params
-    params.require(:hunters_improvement).permit(:hunter_id, :improvement_id, :improvable_id, :improvable_type, :improveable)
+    params.require(:hunters_improvement)
+          .permit(:hunter_id, :improvement_id, :improvable_id, :improvable_type, :improveable)
   end
 end

--- a/app/controllers/hunters_improvements_controller.rb
+++ b/app/controllers/hunters_improvements_controller.rb
@@ -30,6 +30,7 @@ class HuntersImprovementsController < ApplicationController
   def create
     @hunters_improvement = HuntersImprovement.new(hunters_improvement_params)
     @hunters_improvement.hunter = @hunter
+    update_improveable_option
 
     respond_to do |format|
       if @hunters_improvement.save
@@ -53,6 +54,7 @@ class HuntersImprovementsController < ApplicationController
   # PATCH/PUT /hunters_improvements/1.json
   def update
     respond_to do |format|
+      update_improveable_option
       if @hunters_improvement.update(hunters_improvement_params)
         format.html do
           redirect_to hunter_hunters_improvement_url(hunter_id: @hunter.id, id: @hunters_improvement.id),
@@ -98,8 +100,14 @@ class HuntersImprovementsController < ApplicationController
     @improvements = @hunter.available_improvements
   end
 
+  def update_improveable_option
+    return unless @hunters_improvement.improveable
+    raw = JSON.parse(@hunters_improvement.improveable)
+    @hunters_improvement.improveable = raw
+  end
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def hunters_improvement_params
-    params.require(:hunters_improvement).permit(:hunter_id, :improvement_id, :improvable_id, :improvable_type)
+    params.require(:hunters_improvement).permit(:hunter_id, :improvement_id, :improvable_id, :improvable_type, :improveable)
   end
 end

--- a/app/javascript/components/hunters_improvement_form.vue
+++ b/app/javascript/components/hunters_improvement_form.vue
@@ -30,7 +30,6 @@ export default {
       if (!this.selectedOption) {
         return '';
       }
-      console.log(this.selectedOption);
       let option = JSON.parse(this.selectedOption);
       return option.description;
     },
@@ -60,10 +59,12 @@ export default {
         });
     },
     stringifyValue(option) {
-      if (option.id) {
-        return JSON.stringify(option);
-      } else {
-        return JSON.stringify({ 'improvable': option });
+      if (option) {
+        if (option.id) {
+          return JSON.stringify(option);
+        } else {
+          return JSON.stringify({ 'improvable': option });
+        }
       }
     },
   },

--- a/app/javascript/components/hunters_improvement_form.vue
+++ b/app/javascript/components/hunters_improvement_form.vue
@@ -10,43 +10,62 @@
         </option>
       </b-select>
     </b-field>
-    <b-field v-if="this.options.length > 0" label="Options">
-      <b-select v-model="selectedOptionId" placeholder="Select Option" name="hunters_improvement[improvable_id]">
+    <b-field v-if="this.options.length > 0" label="Options" v-bind:message="optionDescription">
+      <b-select v-model="selectedOption" placeholder="Select Option" name="hunters_improvement[improveable]">
         <option
           v-for="option in options"
-          :value="option.id"
-          :key="option.id">
-            {{ option.name }}
+          :value="stringifyValue(option)"
+          :key="optionKey(option)">
+            {{ displayOption(option) }}
         </option>
       </b-select>
     </b-field>
-    <input type="hidden" name="hunters_improvement[improvable_type]" :value="selectedOption.type">
   </section>
 </template>
 
 <script>
 export default {
   computed: {
-    selectedOption: function() {
-      var selected = this.options.find(option => option.id == this.selectedOptionId);
-      return selected || {};
-    }
+    optionDescription: function () {
+      if (!this.selectedOption) {
+        return '';
+      }
+      console.log(this.selectedOption);
+      let option = JSON.parse(this.selectedOption);
+      return option.description;
+    },
   },
   data: function () {
     return {
       improvement: {},
-      selectedOptionId: 1,
+      selectedOption: '',
       options: []
     }
   },
   methods: {
+    displayOption(option) {
+      return option.name ? option.name : option;
+    },
+    optionKey(option) {
+      return option.id ? option.id : option;
+    },
     selectImprovement(improvement) {
       fetch(`/improvements/${this.improvement}.json?hunter_id=${this.hunter_id}`)
         .then(response => response.json())
         .then((improvement) => {
           this.options = improvement['improvable_options'];
+          if (this.options) {
+            this.selectedOption = this.stringifyValue(this.options[0]);
+          }
         });
-    }
+    },
+    stringifyValue(option) {
+      if (option.id) {
+        return JSON.stringify(option);
+      } else {
+        return JSON.stringify({ 'improveable': option });
+      }
+    },
   },
   props: ['hunter_id', 'improvements']
 }

--- a/app/javascript/components/hunters_improvement_form.vue
+++ b/app/javascript/components/hunters_improvement_form.vue
@@ -11,7 +11,7 @@
       </b-select>
     </b-field>
     <b-field v-if="this.options.length > 0" label="Options" v-bind:message="optionDescription">
-      <b-select v-model="selectedOption" placeholder="Select Option" name="hunters_improvement[improveable]">
+      <b-select v-model="selectedOption" placeholder="Select Option" name="hunters_improvement[improvable]">
         <option
           v-for="option in options"
           :value="stringifyValue(option)"
@@ -63,7 +63,7 @@ export default {
       if (option.id) {
         return JSON.stringify(option);
       } else {
-        return JSON.stringify({ 'improveable': option });
+        return JSON.stringify({ 'improvable': option });
       }
     },
   },

--- a/app/models/hunter.rb
+++ b/app/models/hunter.rb
@@ -40,6 +40,6 @@ class Hunter < ApplicationRecord
   #
   # @param move [Move] the move to check
   def advanced?(move)
-    hunters_moves.find_by(move: move).advanced
+    hunters_moves.find_by(move: move)&.advanced
   end
 end

--- a/app/models/hunter.rb
+++ b/app/models/hunter.rb
@@ -2,6 +2,8 @@
 
 # The character appearing in the mystery
 class Hunter < ApplicationRecord
+  MAX_LUCK = 7
+
   belongs_to :playbook
   has_many :gears, through: :hunters_gears
   has_many :hunters_moves
@@ -13,7 +15,7 @@ class Hunter < ApplicationRecord
                                 }
   has_many :improvements, through: :hunters_improvements
   validates :harm, numericality: { less_than_or_equal_to: 7, greater_than_or_equal_to: 0 }
-  validates :luck, numericality: { less_than_or_equal_to: 7, greater_than_or_equal_to: 0 }
+  validates :luck, numericality: { less_than_or_equal_to: MAX_LUCK, greater_than_or_equal_to: 0 }
 
   # List all improvements that are available
   # based on the hunter's playbook, and excludes

--- a/app/models/hunters_improvement.rb
+++ b/app/models/hunters_improvement.rb
@@ -5,7 +5,6 @@
 class HuntersImprovement < ApplicationRecord
   belongs_to :hunter
   belongs_to :improvement
-  belongs_to :improvable, polymorphic: true, optional: true
 
   after_create :apply_improvement
   validate :validate_hunter, on: :create

--- a/app/models/improvement.rb
+++ b/app/models/improvement.rb
@@ -6,7 +6,7 @@
 class Improvement < ApplicationRecord
   IMPROVEMENT_TYPES = %w[Improvement Improvements::RatingBoost
                          Improvements::PlaybookMove Improvements::AnotherMove
-                         Improvements::ChangePlaybook].freeze
+                         Improvements::ChangePlaybook Improvements::GainLuck].freeze
 
   belongs_to :playbook
 

--- a/app/models/improvements/another_move.rb
+++ b/app/models/improvements/another_move.rb
@@ -53,7 +53,9 @@ module Improvements
     end
 
     def improvable_options(hunter)
-      Move.where.not(id: hunter.moves.select(:id)).where.not(playbook_id: playbook_id)
+      Move.where.not(id: hunter.moves.select(:id))
+          .where.not(playbook_id: playbook_id)
+          .select(:id, :name, :description)
     end
   end
 end

--- a/app/models/improvements/another_move.rb
+++ b/app/models/improvements/another_move.rb
@@ -6,7 +6,7 @@ module Improvements
     def apply(hunters_improvement)
       return false if add_errors(hunters_improvement)
 
-      hunters_improvement.hunter.moves << hunters_improvement.improvable
+      hunters_improvement.hunter.moves << move(hunters_improvement)
     end
 
     def add_errors(hunters_improvement)
@@ -17,15 +17,23 @@ module Improvements
     end
 
     def validate_hunter(hunters_improvement)
-      return unless hunter_has_move?(hunters_improvement.hunter, hunters_improvement.improvable)
-      hunters_improvement.errors.add(:hunter, "already has move with id #{hunters_improvement.improvable.id}")
+      return unless hunter_has_move?(hunters_improvement.hunter, move(hunters_improvement))
+      hunters_improvement.errors.add(:hunter, "already has move with id #{move(hunters_improvement).id}")
     end
 
     def validate_improvable(hunters_improvement)
-      move = hunters_improvement.improvable
+      move = move(hunters_improvement)
       hunters_improvement.errors.add(:improvable, 'is not a subclass of Move.') if not_a_move?(move)
       hunters_improvement.errors.add(:improvable, "is from the hunter's playbook #{playbook.name}") if move_matches_playbook?(move)
       hunters_improvement.errors.present?
+    end
+
+    def move(hunters_improvement)
+      begin
+        Move.find(hunters_improvement.improveable&.dig('id'))
+      rescue ActiveRecord::RecordNotFound => e
+        hunters_improvement.errors.add(:improveable, e.message)
+      end
     end
 
     def move_matches_playbook?(move)

--- a/app/models/improvements/another_move.rb
+++ b/app/models/improvements/another_move.rb
@@ -29,11 +29,9 @@ module Improvements
     end
 
     def move(hunters_improvement)
-      begin
-        Move.find(hunters_improvement.improveable&.dig('id'))
-      rescue ActiveRecord::RecordNotFound => e
-        hunters_improvement.errors.add(:improveable, e.message)
-      end
+      Move.find(hunters_improvement.improveable&.dig('id'))
+    rescue ActiveRecord::RecordNotFound => e
+      hunters_improvement.errors.add(:improveable, e.message)
     end
 
     def move_matches_playbook?(move)

--- a/app/models/improvements/another_move.rb
+++ b/app/models/improvements/another_move.rb
@@ -5,7 +5,6 @@ module Improvements
   class AnotherMove < Improvement
     def apply(hunters_improvement)
       return false if add_errors(hunters_improvement)
-
       hunters_improvement.hunter.moves << move(hunters_improvement)
     end
 
@@ -23,27 +22,19 @@ module Improvements
 
     def validate_improvable(hunters_improvement)
       move = move(hunters_improvement)
-      hunters_improvement.errors.add(:improvable, 'is not a subclass of Move.') if not_a_move?(move)
+      return unless move
       hunters_improvement.errors.add(:improvable, "is from the hunter's playbook #{playbook.name}") if move_matches_playbook?(move)
-      hunters_improvement.errors.present?
     end
 
     def move(hunters_improvement)
-      Move.find(hunters_improvement.improveable&.dig('id'))
+      Move.find(hunters_improvement.improvable&.dig('id'))
     rescue ActiveRecord::RecordNotFound => e
-      hunters_improvement.errors.add(:improveable, e.message)
+      hunters_improvement.errors.add(:improvable, e.message)
+      false
     end
 
     def move_matches_playbook?(move)
-      move?(move) && move.playbook == playbook
-    end
-
-    def not_a_move?(move)
-      !move?(move)
-    end
-
-    def move?(move)
-      move.class <= Move
+      move.playbook == playbook
     end
 
     def hunter_has_move?(hunter, move)

--- a/app/models/improvements/change_playbook.rb
+++ b/app/models/improvements/change_playbook.rb
@@ -22,7 +22,7 @@ module Improvements
     end
 
     def improvable_options(_hunter)
-      Playbook.where.not(id: playbook_id)
+      Playbook.where.not(id: playbook_id).select(:id, :name, :description)
     end
 
     def new_playbook(hunters_improvement)

--- a/app/models/improvements/change_playbook.rb
+++ b/app/models/improvements/change_playbook.rb
@@ -13,7 +13,11 @@ module Improvements
 
     def add_errors(hunters_improvement)
       super(hunters_improvement)
-      hunters_improvement.errors.add(:improvable, 'is not a Playbook.') unless playbook?(new_playbook(hunters_improvement))
+      unless playbook?(new_playbook(hunters_improvement))
+        hunters_improvement
+          .errors
+          .add(:improvable, 'is not a Playbook.')
+      end
       hunters_improvement.errors.present?
     end
 
@@ -26,11 +30,9 @@ module Improvements
     end
 
     def new_playbook(hunters_improvement)
-      begin
-        Playbook.find(hunters_improvement.improveable&.dig('id'))
-      rescue ActiveRecord::RecordNotFound => e
-        hunters_improvement.errors.add(:improveable, e.message)
-      end
+      Playbook.find(hunters_improvement.improveable&.dig('id'))
+    rescue ActiveRecord::RecordNotFound => e
+      hunters_improvement.errors.add(:improveable, e.message)
     end
   end
 end

--- a/app/models/improvements/change_playbook.rb
+++ b/app/models/improvements/change_playbook.rb
@@ -30,9 +30,9 @@ module Improvements
     end
 
     def new_playbook(hunters_improvement)
-      Playbook.find(hunters_improvement.improveable&.dig('id'))
+      Playbook.find(hunters_improvement.improvable&.dig('id'))
     rescue ActiveRecord::RecordNotFound => e
-      hunters_improvement.errors.add(:improveable, e.message)
+      hunters_improvement.errors.add(:improvable, e.message)
     end
   end
 end

--- a/app/models/improvements/change_playbook.rb
+++ b/app/models/improvements/change_playbook.rb
@@ -8,12 +8,12 @@ module Improvements
 
       hunters_improvement
         .hunter
-        .update(playbook: hunters_improvement.improvable)
+        .update(playbook: new_playbook(hunters_improvement))
     end
 
     def add_errors(hunters_improvement)
       super(hunters_improvement)
-      hunters_improvement.errors.add(:improvable, 'is not a Playbook.') unless playbook?(hunters_improvement.improvable)
+      hunters_improvement.errors.add(:improvable, 'is not a Playbook.') unless playbook?(new_playbook(hunters_improvement))
       hunters_improvement.errors.present?
     end
 
@@ -23,6 +23,14 @@ module Improvements
 
     def improvable_options(_hunter)
       Playbook.where.not(id: playbook_id)
+    end
+
+    def new_playbook(hunters_improvement)
+      begin
+        Playbook.find(hunters_improvement.improveable&.dig('id'))
+      rescue ActiveRecord::RecordNotFound => e
+        hunters_improvement.errors.add(:improveable, e.message)
+      end
     end
   end
 end

--- a/app/models/improvements/gain_luck.rb
+++ b/app/models/improvements/gain_luck.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Improvements
+  # This is for Improvements like "Get back one used Luck point."
+  class GainLuck < Improvement
+    def apply(hunters_improvement)
+      return false if add_errors(hunters_improvement)
+      hunters_improvement.hunter.luck += 1
+      hunters_improvement.hunter.save
+    end
+
+    def add_errors(hunters_improvement)
+      super(hunters_improvement)
+      validate_hunter hunters_improvement
+      hunters_improvement.errors.present?
+    end
+
+    def validate_hunter(hunters_improvement)
+      return unless max_luck?(hunters_improvement.hunter)
+      hunters_improvement.errors.add(:hunter, 'already has maximum for luck')
+    end
+
+    def max_luck?(hunter)
+      hunter.luck >= Hunter::MAX_LUCK
+    end
+  end
+end

--- a/app/models/improvements/playbook_move.rb
+++ b/app/models/improvements/playbook_move.rb
@@ -44,11 +44,9 @@ module Improvements
     end
 
     def move(hunters_improvement)
-      begin
-        Move.find(hunters_improvement.improveable&.dig('id'))
-      rescue ActiveRecord::RecordNotFound => e
-        hunters_improvement.errors.add(:improveable, e.message)
-      end
+      Move.find(hunters_improvement.improveable&.dig('id'))
+    rescue ActiveRecord::RecordNotFound => e
+      hunters_improvement.errors.add(:improveable, e.message)
     end
 
     def improvable_options(hunter)

--- a/app/models/improvements/playbook_move.rb
+++ b/app/models/improvements/playbook_move.rb
@@ -52,7 +52,10 @@ module Improvements
     end
 
     def improvable_options(hunter)
-      Move.where.not(id: hunter.moves.select(:id)).where(playbook_id: playbook_id)
+      Move
+        .where.not(id: hunter.moves.select(:id))
+        .where(playbook_id: playbook_id)
+        .select(:id, :name, :description)
     end
   end
 end

--- a/app/models/improvements/playbook_move.rb
+++ b/app/models/improvements/playbook_move.rb
@@ -6,7 +6,7 @@ module Improvements
     def apply(hunters_improvement)
       return false if add_errors(hunters_improvement)
 
-      hunters_improvement.hunter.moves << hunters_improvement.improvable
+      hunters_improvement.hunter.moves << move(hunters_improvement)
     end
 
     def add_errors(hunters_improvement)
@@ -17,12 +17,12 @@ module Improvements
     end
 
     def validate_hunter(hunters_improvement)
-      return unless hunter_has_move?(hunters_improvement.hunter, hunters_improvement.improvable)
-      hunters_improvement.errors.add(:hunter, "already has move with id #{hunters_improvement.improvable.id}")
+      return unless hunter_has_move?(hunters_improvement.hunter, move(hunters_improvement))
+      hunters_improvement.errors.add(:hunter, "already has move with id #{move(hunters_improvement).id}")
     end
 
     def validate_improvable(hunters_improvement)
-      move = hunters_improvement.improvable
+      move = move(hunters_improvement)
       hunters_improvement.errors.add(:improvable, 'is not a subclass of Move.') if not_a_move?(move)
       hunters_improvement.errors.add(:improvable, "is not from playbook #{playbook.name}") unless move_matches_playbook?(move)
     end
@@ -41,6 +41,14 @@ module Improvements
 
     def hunter_has_move?(hunter, move)
       hunter.moves.include? move
+    end
+
+    def move(hunters_improvement)
+      begin
+        Move.find(hunters_improvement.improveable&.dig('id'))
+      rescue ActiveRecord::RecordNotFound => e
+        hunters_improvement.errors.add(:improveable, e.message)
+      end
     end
 
     def improvable_options(hunter)

--- a/app/models/improvements/playbook_move.rb
+++ b/app/models/improvements/playbook_move.rb
@@ -23,20 +23,12 @@ module Improvements
 
     def validate_improvable(hunters_improvement)
       move = move(hunters_improvement)
-      hunters_improvement.errors.add(:improvable, 'is not a subclass of Move.') if not_a_move?(move)
+      return unless move
       hunters_improvement.errors.add(:improvable, "is not from playbook #{playbook.name}") unless move_matches_playbook?(move)
     end
 
     def move_matches_playbook?(move)
-      move?(move) && move.playbook == playbook
-    end
-
-    def not_a_move?(move)
-      !move?(move)
-    end
-
-    def move?(move)
-      move.class <= Move
+      move.playbook == playbook
     end
 
     def hunter_has_move?(hunter, move)
@@ -46,7 +38,8 @@ module Improvements
     def move(hunters_improvement)
       Move.find(hunters_improvement.improveable&.dig('id'))
     rescue ActiveRecord::RecordNotFound => e
-      hunters_improvement.errors.add(:improveable, e.message)
+      hunters_improvement.errors.add(:improvable, e.message)
+      false
     end
 
     def improvable_options(hunter)

--- a/app/models/improvements/playbook_move.rb
+++ b/app/models/improvements/playbook_move.rb
@@ -36,7 +36,7 @@ module Improvements
     end
 
     def move(hunters_improvement)
-      Move.find(hunters_improvement.improveable&.dig('id'))
+      Move.find(hunters_improvement.improvable&.dig('id'))
     rescue ActiveRecord::RecordNotFound => e
       hunters_improvement.errors.add(:improvable, e.message)
       false

--- a/app/models/improvements/rating_boost.rb
+++ b/app/models/improvements/rating_boost.rb
@@ -29,7 +29,7 @@ module Improvements
     end
 
     def configured_rating(hunters_improvement)
-      rating || hunters_improvement.improveable&.dig('improveable')
+      rating || hunters_improvement.improvable&.dig('improvable')
     end
   end
 end

--- a/app/models/improvements/rating_boost.rb
+++ b/app/models/improvements/rating_boost.rb
@@ -16,8 +16,11 @@ module Improvements
 
     def add_errors(hunters_improvement)
       super
-      hunter = hunters_improvement.hunter
-      hunters_improvement.errors.add(:hunter, "#{configured_rating(hunters_improvement)} rating would exceed max for improvement.") unless under_max_limit? hunters_improvement
+      unless under_max_limit? hunters_improvement
+        hunters_improvement
+          .errors
+          .add(:hunter, "#{configured_rating(hunters_improvement)} rating would exceed max for improvement.")
+      end
       hunters_improvement.errors.present?
     end
 

--- a/app/models/improvements/rating_boost.rb
+++ b/app/models/improvements/rating_boost.rb
@@ -5,19 +5,28 @@ module Improvements
   class RatingBoost < Improvement
     def apply(hunters_improvement)
       return false if add_errors(hunters_improvement)
-
-      hunters_improvement.hunter.update_attribute(rating, hunters_improvement.hunter.send(rating) + 1)
+      configured_rating = configured_rating(hunters_improvement)
+      current_rating = hunters_improvement.hunter.send(configured_rating)
+      hunters_improvement.hunter.update_attribute(configured_rating, current_rating + 1)
     end
 
-    def under_max_limit?(hunter)
-      hunter.send(rating) < stat_limit
+    def under_max_limit?(hunters_improvement)
+      hunters_improvement.hunter.send(configured_rating(hunters_improvement)) < stat_limit
     end
 
     def add_errors(hunters_improvement)
       super
       hunter = hunters_improvement.hunter
-      hunters_improvement.errors.add(:hunter, "#{rating} rating would exceed max for improvement.") unless under_max_limit? hunter
+      hunters_improvement.errors.add(:hunter, "#{configured_rating(hunters_improvement)} rating would exceed max for improvement.") unless under_max_limit? hunters_improvement
       hunters_improvement.errors.present?
+    end
+
+    def improvable_options(_hunter)
+      rating ? [] : Rating::LIST
+    end
+
+    def configured_rating(hunters_improvement)
+      rating || hunters_improvement.improveable&.dig('improveable')
     end
   end
 end

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -5,5 +5,5 @@
 class Rating < ApplicationRecord
   belongs_to :playbook
 
-  LIST = %i[charm cool sharp tough weird]
+  LIST = %i[charm cool sharp tough weird].freeze
 end

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -4,4 +4,6 @@
 # determines their capability to do something
 class Rating < ApplicationRecord
   belongs_to :playbook
+
+  LIST = %i[charm cool sharp tough weird]
 end

--- a/app/views/hunters/show.html.erb
+++ b/app/views/hunters/show.html.erb
@@ -30,5 +30,5 @@
   </div>
 </div>
 <br />
-<%= link_to 'Edit', edit_hunter_path(@hunter) %> |
-<%= link_to 'Back', hunters_path %>
+<%= link_to 'Edit', edit_hunter_path(@hunter), class: "button is-primary" %>
+<%= link_to 'Back', hunters_path, class: "button" %>

--- a/app/views/hunters_improvements/_form.html.erb
+++ b/app/views/hunters_improvements/_form.html.erb
@@ -11,11 +11,6 @@
     </div>
   <% end %>
 
-<!--   <div class="field">
-    <%= form.label :improvement %>
-    <%= form.collection_select(:improvement_id, @improvements, :id, :description) %>
-  </div> -->
-
   <hunters-improvement-form hunter_id="<%= hunters_improvement.hunter.id %>" :improvements="<%= @improvements.to_json %>"></hunters-improvement-form>
 
   <div class="actions">

--- a/app/views/hunters_improvements/_form.html.erb
+++ b/app/views/hunters_improvements/_form.html.erb
@@ -1,14 +1,16 @@
 <%= form_with(model: [hunters_improvement.hunter, hunters_improvement], local: true) do |form| %>
   <% if hunters_improvement.errors.any? %>
-    <div class="bp3-callout bp3-intent-danger">
-      <h4 class="bp3-heading"><%= pluralize(hunters_improvement.errors.count, "error") %> prohibited this hunters_improvement from being saved:</h4>
-
+    <b-notification
+      type="is-danger"
+      aria-close-label="Close notification"
+      role="alert">
+      <h4><%= pluralize(hunters_improvement.errors.count, "error") %> prohibited this hunters_improvement from being saved:</h4>
       <ul>
-      <% hunters_improvement.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
+        <% hunters_improvement.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
       </ul>
-    </div>
+    </b-notification>
   <% end %>
 
   <hunters-improvement-form hunter_id="<%= hunters_improvement.hunter.id %>" :improvements="<%= @improvements.to_json %>"></hunters-improvement-form>

--- a/app/views/hunters_improvements/index.html.erb
+++ b/app/views/hunters_improvements/index.html.erb
@@ -2,7 +2,7 @@
 
 <h1>Hunters Improvements</h1>
 
-<table class='bp3-html-table'>
+<table class='table'>
   <thead>
     <th>Hunter</th>
     <th>Improvement</th>

--- a/app/views/hunters_improvements/index.html.erb
+++ b/app/views/hunters_improvements/index.html.erb
@@ -24,4 +24,4 @@
 
 <br>
 
-<%= link_to 'New Hunters Improvement', new_hunter_hunters_improvement_path(hunter_id: @hunter.id) %>
+<%= link_to 'New Hunters Improvement', new_hunter_hunters_improvement_path(hunter_id: @hunter.id), class: "button is-primary" %>

--- a/app/views/hunters_improvements/show.html.erb
+++ b/app/views/hunters_improvements/show.html.erb
@@ -1,2 +1,12 @@
+<p>
+  <strong>Hunter:</strong>
+  <%= link_to(@hunters_improvement.hunter.name, @hunters_improvement.hunter) %>
+</p>
+
+<p>
+  <strong>Improvement:</strong>
+  <%= link_to(@hunters_improvement.improvement.description, improvement_path(@hunters_improvement.improvement)) %>
+</p>
+
 <%= link_to 'Edit', edit_hunter_hunters_improvement_path(hunter_id: @hunters_improvement.hunter_id, id: @hunters_improvement.id) %> |
 <%= link_to 'Back', hunter_hunters_improvements_path(hunter_id: @hunters_improvement.hunter_id) %>

--- a/app/views/improvements/index.html.erb
+++ b/app/views/improvements/index.html.erb
@@ -2,7 +2,7 @@
 
 <h1>Improvements</h1>
 
-<table>
+<table class="table">
   <thead>
     <tr>
       <th>Playbook</th>

--- a/app/views/improvements/show.html.erb
+++ b/app/views/improvements/show.html.erb
@@ -6,6 +6,11 @@
 </p>
 
 <p>
+  <strong>Advanced:</strong>
+  <%= @improvement.advanced %>
+</p>
+
+<p>
   <strong>Type:</strong>
   <%= @improvement.type %>
 </p>

--- a/app/views/improvements/show.json.jbuilder
+++ b/app/views/improvements/show.json.jbuilder
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 
 json.partial! 'improvements/improvement', improvement: @improvement
-if @improvable_options
-  json.improvable_options @improvable_options
-end
+json.improvable_options @improvable_options if @improvable_options

--- a/app/views/improvements/show.json.jbuilder
+++ b/app/views/improvements/show.json.jbuilder
@@ -2,8 +2,5 @@
 
 json.partial! 'improvements/improvement', improvement: @improvement
 if @improvable_options
-  json.improvable_options @improvable_options do |option|
-    json.extract!(option, :id, :name)
-    json.type option.class.to_s
-  end
+  json.improvable_options @improvable_options
 end

--- a/app/views/moves/_moves.html.erb
+++ b/app/views/moves/_moves.html.erb
@@ -1,6 +1,6 @@
 <% moves.each do |move| %>
   <ul>
-    <li><%= move.name %>: <%= move.description %>
+    <li><strong><%= move.name %>:</strong><%= move.description %>
       <% if move.rollable? && hunter %>
         <%= link_to 'Roll', hunter_path(hunter), data: { confirm: "#{move.roll_results(hunter)}" } %>
       <% else %>

--- a/db/migrate/20200126141817_add_improvable_to_hunters_improvements.rb
+++ b/db/migrate/20200126141817_add_improvable_to_hunters_improvements.rb
@@ -1,0 +1,5 @@
+class AddImprovableToHuntersImprovements < ActiveRecord::Migration[6.0]
+  def change
+    add_column :hunters_improvements, :improveable, :jsonb
+  end
+end

--- a/db/migrate/20200202151037_remove_improvable_from_hunters_improvements.rb
+++ b/db/migrate/20200202151037_remove_improvable_from_hunters_improvements.rb
@@ -1,0 +1,6 @@
+class RemoveImprovableFromHuntersImprovements < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :hunters_improvements, :improvable_type, :string
+    remove_column :hunters_improvements, :improvable_id, :integer
+  end
+end

--- a/db/migrate/20200202151306_rename_improveable_on_hunters_improvements.rb
+++ b/db/migrate/20200202151306_rename_improveable_on_hunters_improvements.rb
@@ -1,0 +1,5 @@
+class RenameImproveableOnHuntersImprovements < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :hunters_improvements, :improveable, :improvable
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_26_141817) do
+ActiveRecord::Schema.define(version: 2020_02_02_151306) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,10 +53,7 @@ ActiveRecord::Schema.define(version: 2020_01_26_141817) do
     t.string "hunters_improvements"
     t.integer "hunter_id"
     t.integer "improvement_id"
-    t.string "improvable_type"
-    t.bigint "improvable_id"
-    t.jsonb "improveable"
-    t.index ["improvable_type", "improvable_id"], name: "index_hunters_improvements_on_improvable_type_and_improvable_id"
+    t.jsonb "improvable"
   end
 
   create_table "hunters_moves", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_22_193543) do
+ActiveRecord::Schema.define(version: 2020_01_26_141817) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 2020_01_22_193543) do
     t.integer "improvement_id"
     t.string "improvable_type"
     t.bigint "improvable_id"
+    t.jsonb "improveable"
     t.index ["improvable_type", "improvable_id"], name: "index_hunters_improvements_on_improvable_type_and_improvable_id"
   end
 

--- a/db/seeds/improvement.seeds.rb
+++ b/db/seeds/improvement.seeds.rb
@@ -72,6 +72,12 @@ after :playbook do
     advanced: true
   },
   {
+    description: 'Get back one used Luck point.',
+    playbook: @chosen,
+    type: 'Improvements::GainLuck',
+    advanced: true
+  },
+  {
     description: 'Retire this Hunter to safety.',
     playbook: @chosen,
     advanced: true

--- a/db/seeds/improvement.seeds.rb
+++ b/db/seeds/improvement.seeds.rb
@@ -65,6 +65,13 @@ after :playbook do
     playbook: @chosen
   },
   {
+    description: 'Get +1 to any rating, max +3.',
+    playbook: @chosen,
+    type: 'Improvements::RatingBoost',
+    stat_limit: 3,
+    advanced: true
+  },
+  {
     description: 'Retire this Hunter to safety.',
     playbook: @chosen,
     advanced: true

--- a/spec/controllers/hunters_improvements_controller_spec.rb
+++ b/spec/controllers/hunters_improvements_controller_spec.rb
@@ -97,17 +97,17 @@ RSpec.describe HuntersImprovementsController, type: :controller do
         it { is_expected.to have_http_status(:created) }
       end
 
-      context 'with json improveable' do
-        let(:attributes) { { hunter_id: hunter.id, improvement_id: valid_improvement.id, improveable: '{"id":25,"name":"Ancient Fighting Arts","description":"When using an old-fashioned hand weapon, you inflict +1 harm and get +1\nwhenever you roll protect someone."}' } }
+      context 'with json improvable' do
+        let(:attributes) { { hunter_id: hunter.id, improvement_id: valid_improvement.id, improvable: '{"id":25,"name":"Ancient Fighting Arts","description":"When using an old-fashioned hand weapon, you inflict +1 harm and get +1\nwhenever you roll protect someone."}' } }
         let(:format_type) { :html }
 
         it 'creates a new HuntersImprovement' do
           expect { subject }.to change(HuntersImprovement, :count).by(1)
         end
 
-        it 'has a well-formatted json improveable' do
+        it 'has a well-formatted json improvable' do
           subject
-          expect(HuntersImprovement.last.improveable['id']).to eq 25
+          expect(HuntersImprovement.last.improvable['id']).to eq 25
         end
       end
     end

--- a/spec/controllers/hunters_improvements_controller_spec.rb
+++ b/spec/controllers/hunters_improvements_controller_spec.rb
@@ -96,6 +96,20 @@ RSpec.describe HuntersImprovementsController, type: :controller do
 
         it { is_expected.to have_http_status(:created) }
       end
+
+      context 'with json improveable' do
+        let(:attributes) { { hunter_id: hunter.id, improvement_id: valid_improvement.id, improveable: '{"id":25,"name":"Ancient Fighting Arts","description":"When using an old-fashioned hand weapon, you inflict +1 harm and get +1\nwhenever you roll protect someone."}' } }
+        let(:format_type) { :html }
+
+        it 'creates a new HuntersImprovement' do
+          expect { subject }.to change(HuntersImprovement, :count).by(1)
+        end
+
+        it 'has a well-formatted json improveable' do
+          subject
+          expect(HuntersImprovement.last.improveable['id']).to eq 25
+        end
+      end
     end
 
     context 'with invalid params' do

--- a/spec/factories/improvements.rb
+++ b/spec/factories/improvements.rb
@@ -31,6 +31,12 @@ FactoryBot.define do
   factory :change_playbook, class: Improvements::ChangePlaybook do
     playbook
     description { 'Change this hunter to a new type.' }
-    type { Improvements::ChangePlaybook }
+    type { 'Improvements::ChangePlaybook' }
+  end
+
+  factory :gain_luck, class: Improvements::GainLuck do
+    playbook
+    description { 'Get back one used Luck point.'}
+    type { 'Improvements::GainLuck' }
   end
 end

--- a/spec/models/hunter_spec.rb
+++ b/spec/models/hunter_spec.rb
@@ -61,13 +61,13 @@ RSpec.describe Hunter, type: :model do
     context 'with advanced move' do
       let!(:hunter_move) { create(:hunters_move, hunter: hunter, move: move, advanced: true) }
 
-      it { be_truthy }
+      it { is_expected.to be_truthy }
     end
 
     context 'with not advanced move' do
       let!(:hunter_move) { create(:hunters_move, hunter: hunter, move: move) }
 
-      it { be_falsey }
+      it { is_expected.to be_falsey }
     end
   end
 end

--- a/spec/models/improvements/another_move_spec.rb
+++ b/spec/models/improvements/another_move_spec.rb
@@ -67,28 +67,6 @@ RSpec.describe Improvements::AnotherMove, type: :model do
     end
   end
 
-  describe '#not_a_move?' do
-    subject { another_move.not_a_move?(move) }
-
-    context 'Moves::Base' do
-      let(:move) { create(:move) }
-
-      it { is_expected.to be_falsey }
-    end
-
-    context 'Moves::Descriptive' do
-      let(:move) { create :moves_descriptive }
-
-      it { is_expected.to be_falsey }
-    end
-
-    context 'Playbook' do
-      let(:move) { create :playbook }
-
-      it { is_expected.to be_truthy }
-    end
-  end
-
   describe '#hunter_has_move?' do
     subject { another_move.hunter_has_move?(hunter, move) }
 

--- a/spec/models/improvements/another_move_spec.rb
+++ b/spec/models/improvements/another_move_spec.rb
@@ -4,7 +4,12 @@ require 'rails_helper'
 
 RSpec.describe Improvements::AnotherMove, type: :model do
   let(:another_move) { create(:another_move) }
-  let(:hunters_improvement) { build :hunters_improvement, improvement: another_move, hunter: hunter, improvable: move }
+  let(:hunters_improvement) {
+    build :hunters_improvement,
+          hunter: hunter,
+          improvement: another_move,
+          improveable: {'id': move.id, 'name': move.name, 'description': move.description }
+  }
   let(:hunter) { create :hunter, playbook: another_move.playbook  }
   let(:move) { create :moves_rollable, playbook: create(:playbook) }
 
@@ -96,6 +101,15 @@ RSpec.describe Improvements::AnotherMove, type: :model do
     context 'hunter does not have move' do
       it { is_expected.to be_falsey }
     end
+  end
+
+  describe '#move' do
+    subject { another_move.move(hunters_improvement) }
+
+    let(:move) { create :move }
+    let(:hunters_improvement) { build :hunters_improvement, improvement: another_move, hunter: hunter, improveable: { "id": move.id, "name": move.name, "description": move.description } }
+
+    it { is_expected.to eq Move.find move.id }
   end
 
   describe '#add_errors' do

--- a/spec/models/improvements/another_move_spec.rb
+++ b/spec/models/improvements/another_move_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Improvements::AnotherMove, type: :model do
     build :hunters_improvement,
           hunter: hunter,
           improvement: another_move,
-          improveable: {'id': move.id, 'name': move.name, 'description': move.description }
+          improvable: {'id': move.id, 'name': move.name, 'description': move.description }
   }
   let(:hunter) { create :hunter, playbook: another_move.playbook  }
   let(:move) { create :moves_rollable, playbook: create(:playbook) }
@@ -85,7 +85,7 @@ RSpec.describe Improvements::AnotherMove, type: :model do
     subject { another_move.move(hunters_improvement) }
 
     let(:move) { create :move }
-    let(:hunters_improvement) { build :hunters_improvement, improvement: another_move, hunter: hunter, improveable: { "id": move.id, "name": move.name, "description": move.description } }
+    let(:hunters_improvement) { build :hunters_improvement, improvement: another_move, hunter: hunter, improvable: { "id": move.id, "name": move.name, "description": move.description } }
 
     it { is_expected.to eq Move.find move.id }
   end
@@ -104,7 +104,7 @@ RSpec.describe Improvements::AnotherMove, type: :model do
       let(:move) { create(:playbook) }
       it 'adds errors to the hunters improvement' do
         subject
-        expect(hunters_improvement.errors.full_messages).to include 'Improvable is not a subclass of Move.'
+        expect(hunters_improvement.errors.full_messages).to include "Improvable Couldn't find Move with 'id'=#{move.id}"
       end
     end
   end

--- a/spec/models/improvements/change_playbook_spec.rb
+++ b/spec/models/improvements/change_playbook_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Improvements::ChangePlaybook, type: :model do
     build :hunters_improvement,
           improvement: change_playbook,
           hunter: hunter,
-          improvable: playbook
+          improveable: {"id": playbook.id }
   end
 
   describe '#apply' do
@@ -17,7 +17,7 @@ RSpec.describe Improvements::ChangePlaybook, type: :model do
       build :hunters_improvement,
              improvement: change_playbook,
              hunter: hunter,
-             improvable: playbook
+             improveable: {"id": playbook.id }
            end
     let(:hunter) { create :hunter, playbook: change_playbook.playbook }
     let(:playbook) { create :playbook }

--- a/spec/models/improvements/change_playbook_spec.rb
+++ b/spec/models/improvements/change_playbook_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Improvements::ChangePlaybook, type: :model do
     build :hunters_improvement,
           improvement: change_playbook,
           hunter: hunter,
-          improveable: {"id": playbook.id }
+          improvable: {"id": playbook.id }
   end
 
   describe '#apply' do
@@ -17,7 +17,7 @@ RSpec.describe Improvements::ChangePlaybook, type: :model do
       build :hunters_improvement,
              improvement: change_playbook,
              hunter: hunter,
-             improveable: {"id": playbook.id }
+             improvable: {"id": playbook.id }
            end
     let(:hunter) { create :hunter, playbook: change_playbook.playbook }
     let(:playbook) { create :playbook }

--- a/spec/models/improvements/gain_luck_spec.rb
+++ b/spec/models/improvements/gain_luck_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Improvements::GainLuck, type: :model do
+  let(:gain_luck) { create(:gain_luck) }
+  let(:hunters_improvement) { build :hunters_improvement, hunter: hunter, improvement: gain_luck }
+  let(:hunter) { create :hunter, playbook: gain_luck.playbook, luck: 1 }
+
+  describe '#apply' do
+    subject { gain_luck.apply(hunters_improvement) }
+
+    it "increases the hunter's luck by 1" do
+      subject
+      expect(hunter.reload.luck).to eq 2
+    end
+
+    context 'hunter already has maximum luck' do
+      let(:hunter) { create :hunter, playbook: gain_luck.playbook, luck: Hunter::MAX_LUCK }
+
+      it 'adds errors to hunters improvement' do
+        subject
+        expect(hunters_improvement.errors.full_messages).to include('Hunter already has maximum for luck')
+      end
+
+      it 'does not set luck to 8' do
+        subject
+        expect(hunter.reload.luck).to eq Hunter::MAX_LUCK
+      end
+    end
+  end
+end

--- a/spec/models/improvements/playbook_move_spec.rb
+++ b/spec/models/improvements/playbook_move_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Improvements::PlaybookMove, type: :model do
   let(:playbook_move) { create(:playbook_move) }
-  let(:hunters_improvement) { build :hunters_improvement, improvement: playbook_move, hunter: hunter, improvable: move }
+  let(:hunters_improvement) { build :hunters_improvement, improvement: playbook_move, hunter: hunter, improveable: { "id": move.id } }
   let(:hunter) { create :hunter, playbook: playbook_move.playbook  }
   let(:move) { create :moves_rollable, playbook: playbook_move.playbook }
 

--- a/spec/models/improvements/playbook_move_spec.rb
+++ b/spec/models/improvements/playbook_move_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Improvements::PlaybookMove, type: :model do
   let(:playbook_move) { create(:playbook_move) }
-  let(:hunters_improvement) { build :hunters_improvement, improvement: playbook_move, hunter: hunter, improveable: { "id": move.id } }
+  let(:hunters_improvement) { build :hunters_improvement, improvement: playbook_move, hunter: hunter, improvable: { "id": move.id } }
   let(:hunter) { create :hunter, playbook: playbook_move.playbook  }
   let(:move) { create :moves_rollable, playbook: playbook_move.playbook }
 

--- a/spec/models/improvements/playbook_move_spec.rb
+++ b/spec/models/improvements/playbook_move_spec.rb
@@ -62,28 +62,6 @@ RSpec.describe Improvements::PlaybookMove, type: :model do
     end
   end
 
-  describe '#not_a_move?' do
-    subject { playbook_move.not_a_move?(move) }
-
-    context 'Moves::Base' do
-      let(:move) { create(:move) }
-
-      it { is_expected.to be_falsey }
-    end
-
-    context 'Moves::Descriptive' do
-      let(:move) { create :moves_descriptive }
-
-      it { is_expected.to be_falsey }
-    end
-
-    context 'Playbook' do
-      let(:move) { create :playbook }
-
-      it { is_expected.to be_truthy }
-    end
-  end
-
   describe '#hunter_has_move?' do
     subject { playbook_move.hunter_has_move?(hunter, move) }
 
@@ -112,7 +90,7 @@ RSpec.describe Improvements::PlaybookMove, type: :model do
       let(:move) { create(:playbook) }
       it 'adds errors to the hunters improvement' do
         subject
-        expect(hunters_improvement.errors.full_messages).to include 'Improvable is not a subclass of Move.'
+        expect(hunters_improvement.errors.full_messages).to include "Improvable Couldn't find Move with 'id'=#{move.id}"
       end
     end
   end

--- a/spec/models/improvements/rating_boost_spec.rb
+++ b/spec/models/improvements/rating_boost_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Improvements::RatingBoost, type: :model do
 
       context 'configured rating boost' do
         let(:rating_boost) { create :rating_boost, rating: nil }
-        let(:hunters_improvement) { build(:hunters_improvement, hunter: hunter, improvement: rating_boost, improveable: { improveable: 'cool' }) }
+        let(:hunters_improvement) { build(:hunters_improvement, hunter: hunter, improvement: rating_boost, improvable: { improvable: 'cool' }) }
 
         it { expect { subject }.to change(hunter, :cool).by(1) }
         it "sets the hunter's cool to 1" do
@@ -90,7 +90,7 @@ RSpec.describe Improvements::RatingBoost, type: :model do
 
     context 'rating configured on hunters improvement' do
       let(:rating_boost) { create :rating_boost, rating: nil }
-      let(:hunters_improvement) { create(:hunters_improvement, hunter: hunter, improvement: rating_boost, improveable: { improveable: 'cool' }) }
+      let(:hunters_improvement) { create(:hunters_improvement, hunter: hunter, improvement: rating_boost, improvable: { improvable: 'cool' }) }
 
       it { is_expected.to eq 'cool' }
     end

--- a/spec/models/improvements/rating_boost_spec.rb
+++ b/spec/models/improvements/rating_boost_spec.rb
@@ -4,20 +4,31 @@ require 'rails_helper'
 
 RSpec.describe Improvements::RatingBoost, type: :model do
   let(:rating_boost) { create :rating_boost }
-  let(:hunters_improvement) { create(:hunters_improvement, hunter: hunter, improvement: rating_boost) }
+  let(:hunters_improvement) { build(:hunters_improvement, hunter: hunter, improvement: rating_boost) }
 
   describe '#apply' do
     subject { rating_boost.apply(hunters_improvement) }
 
     context 'valid hunter' do
-      let(:hunter) { create :hunter, playbook: rating_boost.playbook, charm: 2 }
+      let(:hunter) { create :hunter, playbook: rating_boost.playbook, charm: 2, cool: 0 }
 
       it { expect { subject }.to change(hunter, :charm).by(1) }
+
+      context 'configured rating boost' do
+        let(:rating_boost) { create :rating_boost, rating: nil }
+        let(:hunters_improvement) { build(:hunters_improvement, hunter: hunter, improvement: rating_boost, improveable: { improveable: 'cool' }) }
+
+        it { expect { subject }.to change(hunter, :cool).by(1) }
+        it "sets the hunter's cool to 1" do
+          subject
+          expect(hunter.cool).to eq 1
+        end
+      end
     end
   end
 
   describe '#under_max_limit?' do
-    subject { rating_boost.under_max_limit?(hunter) }
+    subject { rating_boost.under_max_limit?(hunters_improvement) }
 
     context 'hunter with valid rating' do
       let(:hunter) { create :hunter,  playbook: rating_boost.playbook, charm: 2 }
@@ -65,6 +76,23 @@ RSpec.describe Improvements::RatingBoost, type: :model do
         subject
         expect(hunters_improvement.errors).to be_empty
       end
+    end
+  end
+
+  describe '#configured_rating' do
+    subject { rating_boost.configured_rating(hunters_improvement) }
+
+    let(:hunter) { create :hunter, playbook: rating_boost.playbook }
+
+    context 'rating configured on improvement' do
+      it { is_expected.to eq 'charm' }
+    end
+
+    context 'rating configured on hunters improvement' do
+      let(:rating_boost) { create :rating_boost, rating: nil }
+      let(:hunters_improvement) { create(:hunters_improvement, hunter: hunter, improvement: rating_boost, improveable: { improveable: 'cool' }) }
+
+      it { is_expected.to eq 'cool' }
     end
   end
 end


### PR DESCRIPTION
 - Added a new Improveable JSONB column to allow for a greater variety of HunterImprovement configs
   - Arrays of object, strings, and singular objects
- Improved UI of Hunter Improvements, Improvements, and Move on the Hunter#show page
- Fix bug with hunter move where rolling over a 12 on a nonadvanced move would result in a 500

To Do:
- [x] Refactor old improvements to no longer use polymorphic association
- [x] remove improvable_type and improvable_id
- [x] change improveable to improvable
- [x] Write a spec for `advanced?` on Hunter
- [x] See if JSON needs to be stringified