### PR TITLE
Rubocop - Activated Extensions

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -6,6 +6,6 @@ plugins:
     enabled: true
   rubocop:
     enabled: true
-    channel: rubocop-0-67
+    channel: rubocop-0-72
   stylelint:
     enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,10 @@
-# require: rubocop-performance
+require:
+  - rubocop-performance
+  - rubocop-rails
+  - rubocop-rspec
 AllCops:
   Excludes:
     - db/schema.rb
 
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
-
-Metrics/LineLength:
-  Description: 'Limit lines to 120 characters.'
-  Max: 120


### PR DESCRIPTION
Activated Performance, Rails, and RSpec rubocop extensions

Remove 120 line limit, because the 80 looks better at 150%.