### PR TITLE
Add Customize Moves to Edit Page

### DIFF
--- a/app/controllers/hunters_controller.rb
+++ b/app/controllers/hunters_controller.rb
@@ -60,6 +60,7 @@ class HuntersController < ApplicationController
   # @see HuntersController#hunter_params See hunter_params for accepted parameters
   def update
     respond_to do |format|
+      @hunter.user ||= current_user
       if @hunter.update(hunter_params)
         format.html { redirect_to hunter_path(@hunter), notice: 'Hunter was successfully updated.' }
         format.json { render :show, status: :ok, location: @hunter }

--- a/app/controllers/hunters_controller.rb
+++ b/app/controllers/hunters_controller.rb
@@ -108,6 +108,6 @@ class HuntersController < ApplicationController
   # @return [ActionController::Parameters]
   def hunter_params
     params.require(:hunter)
-          .permit(:name, :playbook_id, :harm, :luck, :experience, :charm, :cool, :sharp, :tough, :weird)
+          .permit(:name, :playbook_id, :harm, :luck, :experience, :charm, :cool, :sharp, :tough, :weird, move_ids: [])
   end
 end

--- a/app/controllers/moves_controller.rb
+++ b/app/controllers/moves_controller.rb
@@ -8,6 +8,7 @@ class MovesController < ApplicationController
   # GET /moves.json
   def index
     @moves = params[:basic] ? Moves::Basic.all : Move.all
+    @moves = Move.with_hunter_moves(params[:hunter_id]) if params[:hunter_id]
     @moves = @moves.where(playbook_id: params[:playbook_id]) if params[:playbook_id]
   end
 

--- a/app/controllers/moves_controller.rb
+++ b/app/controllers/moves_controller.rb
@@ -30,7 +30,6 @@ class MovesController < ApplicationController
   # POST /moves.json
   def create
     @move = Move.new(move_params)
-
     respond_to do |format|
       if @move.save
         format.html { redirect_to move_path(@move), notice: 'Move was successfully created.' }

--- a/app/javascript/components/hunter_moves.vue
+++ b/app/javascript/components/hunter_moves.vue
@@ -1,0 +1,21 @@
+<template>
+  <ul>
+    <li v-for="move in moves"><strong>{{move.name}}:</strong> {{move.description}}</li>
+  </ul>
+</template>
+
+<script>
+export default {
+  data: function () {
+    return {
+      moves: []
+    }
+  },
+  mounted: function() {
+    fetch(`/moves.json?hunter_id=${this.hunter_id}`)
+      .then(response => response.json())
+      .then((moves) => this.moves = moves);
+  },
+  props: ['hunter_id'],
+}
+</script>

--- a/app/javascript/components/hunter_moves.vue
+++ b/app/javascript/components/hunter_moves.vue
@@ -1,20 +1,56 @@
 <template>
-  <ul>
-    <li v-for="move in moves"><strong>{{move.name}}:</strong> {{move.description}}</li>
-  </ul>
+  <div>
+    <ul>
+      <li v-for="move in moves">
+        <input type="checkbox" :id="move.id" :value="move" :checked="move.has_move" v-model="checkedMoves">
+        <strong>{{move.name}}:</strong> {{move.description}}
+      </li>
+    </ul>
+    <b-button @click="submitMoves">Submit Moves</b-button>
+  </div>
 </template>
 
 <script>
+import Rails from "@rails/ujs"
+
 export default {
   data: function () {
     return {
-      moves: []
+      moves: [],
+      checkedMoves: []
+    }
+  },
+  methods: {
+    selectedMoves: function() {
+      return this.moves.filter((move) => {
+        return move.has_move;
+      });
+    },
+    submitMoves() {
+      const hunter_params = {
+        id: this.hunter_id,
+        hunter: { move_ids: this.checkedMoves.map(move => (move.id)) }
+      };
+      Rails.ajax({
+        url: `/hunters/${this.hunter_id}`,
+        type: 'PUT',
+        beforeSend(xhr, options) {
+          xhr.setRequestHeader('Content-Type', 'application/json; charset=UTF-8');
+          // Workaround: add options.data late to avoid Content-Type header to already being set in stone
+          // https://github.com/rails/rails/blob/master/actionview/app/assets/javascripts/rails-ujs/utils/ajax.coffee#L53
+          options.data = JSON.stringify(hunter_params);
+          return true;
+        }
+      });
     }
   },
   mounted: function() {
     fetch(`/moves.json?hunter_id=${this.hunter_id}`)
       .then(response => response.json())
-      .then((moves) => this.moves = moves);
+      .then((moves) => {
+        this.moves = moves;
+        this.checkedMoves = this.selectedMoves();
+      });
   },
   props: ['hunter_id'],
 }

--- a/app/javascript/components/hunter_moves.vue
+++ b/app/javascript/components/hunter_moves.vue
@@ -2,8 +2,10 @@
   <div>
     <ul>
       <li v-for="move in moves">
-        <input type="checkbox" :id="move.id" :value="move" :checked="move.has_move" v-model="checkedMoves">
-        <strong>{{move.name}}:</strong> {{move.description}}
+        <b-checkbox :id="move.id" :native-value="move" :checked="move.has_move" v-model="checkedMoves">
+          <strong>{{move.name}}</strong>
+        </b-checkbox>
+        <p>{{move.description}}</p>
       </li>
     </ul>
     <b-button @click="submitMoves">Submit Moves</b-button>

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -20,12 +20,13 @@ import 'buefy/dist/buefy.css'
 // Components
 import HuntersImprovementForm from '../components/hunters_improvement_form.vue'
 import HunterRatings from '../components/hunter_ratings.vue'
+import HunterMoves from '../components/hunter_moves.vue'
 
 Vue.use(Buefy, TurbolinksAdapter)
 
 document.addEventListener('turbolinks:load', () => {
   const app = new Vue({
     el: '#vue-app',
-    components: { HuntersImprovementForm, HunterRatings },
+    components: { HuntersImprovementForm, HunterMoves, HunterRatings },
   }).default
 })

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -3,7 +3,8 @@
 // a relevant structure within app/javascript and only use these pack files to reference
 // that code so it'll be compiled.
 
-require("@rails/ujs").start()
+import Rails from "@rails/ujs"
+Rails.start()
 require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")

--- a/app/models/hunter.rb
+++ b/app/models/hunter.rb
@@ -9,6 +9,7 @@ class Hunter < ApplicationRecord
   has_and_belongs_to_many :gears, join_table: :hunters_gears
   has_many :hunters_moves
   has_many :moves, through: :hunters_moves
+  accepts_nested_attributes_for :moves
   has_many :hunters_improvements
   validates_associated :hunters_improvements,
                        message: lambda { |_class_obj, obj|

--- a/app/models/hunter.rb
+++ b/app/models/hunter.rb
@@ -45,4 +45,9 @@ class Hunter < ApplicationRecord
   def advanced?(move)
     !!(hunters_moves.find_by(move: move)&.advanced)
   end
+
+  # Check whether the hunter has lost enough health to fall unstable
+  def unstable?
+    harm > 3
+  end
 end

--- a/app/models/hunter.rb
+++ b/app/models/hunter.rb
@@ -6,7 +6,7 @@ class Hunter < ApplicationRecord
 
   belongs_to :playbook
   belongs_to :user
-  has_many :gears, through: :hunters_gears
+  has_and_belongs_to_many :gears, join_table: :hunters_gears
   has_many :hunters_moves
   has_many :moves, through: :hunters_moves
   has_many :hunters_improvements

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -7,6 +7,12 @@ class Move < ApplicationRecord
   belongs_to :playbook, optional: true
   has_many :hunters_moves
 
+  scope :not_basic, -> { where.not(type: 'Moves::Basic') }
+  scope :with_hunter_moves, (lambda do |hunter_id|
+    includes(:hunters_moves)
+      .where(hunters_moves: { hunter_id: [hunter_id, nil] })
+  end)
+
   validates :type, inclusion: { in: MOVE_TYPES }
 
   enum rating: { charm: 0, cool: 1, sharp: 2, tough: 3, weird: 4 }

--- a/app/views/hunters/edit.html.erb
+++ b/app/views/hunters/edit.html.erb
@@ -8,6 +8,6 @@
   </div>
   <div class="column">
     <hunter-moves hunter_id=<%= "#{@hunter.id}" %>></hunter-moves>
-    <!-- <hunter-gear hunter_id=<%= "#{@hunter.id}" %>></hunter-gear> -->
   </div>
+      <!-- <hunter-gear hunter_id=<%= "#{@hunter.id}" %>></hunter-gear> -->
 </div>

--- a/app/views/hunters/edit.html.erb
+++ b/app/views/hunters/edit.html.erb
@@ -1,6 +1,13 @@
 <h1>Editing Hunter</h1>
 
-<%= render 'form', hunter: @hunter %>
-
-<%= link_to 'Show', @hunter %> |
-<%= link_to 'Back', hunters_path %>
+<div class="columns">
+  <div class="column">
+    <%= render 'form', hunter: @hunter %>
+    <%= link_to 'Show', @hunter %> |
+    <%= link_to 'Back', hunters_path %>
+  </div>
+  <div class="column">
+    <hunter-moves hunter_id=<%= "#{@hunter.id}" %>></hunter-moves>
+    <!-- <hunter-gear hunter_id=<%= "#{@hunter.id}" %>></hunter-gear> -->
+  </div>
+</div>

--- a/app/views/hunters/show.html.erb
+++ b/app/views/hunters/show.html.erb
@@ -6,7 +6,7 @@
 
     <p>
       <strong>Harm:</strong>
-      <%= @hunter.harm %>
+      <%= @hunter.harm %> <%= @hunter.unstable? ? 'UNSTABLE' : '' %>
     </p>
 
     <p>

--- a/app/views/hunters/show.html.erb
+++ b/app/views/hunters/show.html.erb
@@ -25,7 +25,13 @@
   <div class="column">
     <p>
       <h4>Moves</h4>
-      <%= render "moves/moves", moves: @hunter.moves, hunter: @hunter %>
+      <%= render "moves/moves", moves: @hunter.moves.not_basic, hunter: @hunter %>
+    </p>
+  </div>
+  <div class="column">
+    <p>
+      <h4>Gear</h4>
+      <%= render "gears/gears", gears: @hunter.gears %>
     </p>
   </div>
 </div>

--- a/app/views/moves/index.json.jbuilder
+++ b/app/views/moves/index.json.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-json.array! @moves do |move|
-  json.partial! 'moves/moves', move: move
-  json.has_move move.hunters_move.exists? if params[:hunter_id]
+json.array!(@moves) do |move|
+  json.partial! 'moves/move', move: move
+  json.has_move move.hunters_moves.exists? if params[:hunter_id]
 end

--- a/app/views/moves/index.json.jbuilder
+++ b/app/views/moves/index.json.jbuilder
@@ -1,3 +1,6 @@
 # frozen_string_literal: true
 
-json.array! @moves, partial: 'moves/move', as: :move
+json.array! @moves do |move|
+  json.partial! 'moves/moves', move: move
+  json.has_move move.hunters_move.exists? if params[:hunter_id]
+end

--- a/spec/controllers/moves_controller_spec.rb
+++ b/spec/controllers/moves_controller_spec.rb
@@ -56,6 +56,13 @@ RSpec.describe MovesController, type: :controller do
         expect(resp.count).to eq 1
       end
     end
+
+    context 'for a hunter' do
+      let(:params) { { hunter_id: hunter.id} }
+      let(:hunter) { create :hunter }
+      it 'display if the hunter has the move' do
+      end
+    end
   end
 
   describe 'GET #show' do

--- a/spec/controllers/moves_controller_spec.rb
+++ b/spec/controllers/moves_controller_spec.rb
@@ -41,26 +41,44 @@ RSpec.describe MovesController, type: :controller do
       expect(response).to be_successful
     end
 
-    context 'when playbook_id is supplied' do
-      render_views
-      let(:playbook) { create :playbook }
-      let(:params) { { playbook_id: playbook.id } }
-      let!(:move) { create(:move, playbook: playbook) }
-      let!(:another_pb_move) { create :move }
+    context 'json format' do
       let(:format_type) { :json }
+      render_views
 
-      it 'filters for moves associated with playbook' do
-        subject
-        resp = JSON.parse(response.body)
-        expect(resp.dig(0, 'id')).to eq(move.id)
-        expect(resp.count).to eq 1
+      context 'when playbook_id is supplied' do
+        let(:playbook) { create :playbook }
+        let(:params) { { playbook_id: playbook.id } }
+        let!(:move) { create(:move, playbook: playbook) }
+        let!(:another_pb_move) { create :move }
+
+        it 'filters for moves associated with playbook' do
+          subject
+          resp = JSON.parse(response.body)
+          expect(resp.dig(0, 'id')).to eq(move.id)
+          expect(resp.count).to eq 1
+        end
       end
-    end
 
-    context 'for a hunter' do
-      let(:params) { { hunter_id: hunter.id} }
-      let(:hunter) { create :hunter }
-      it 'display if the hunter has the move' do
+      context 'for a hunter' do
+        let(:params) { { hunter_id: hunter.id} }
+        let(:hunter) { create :hunter }
+        let!(:move) { create :move }
+
+        it 'does not include has_move' do
+          subject
+          resp = JSON.parse(response.body)
+          expect(resp.dig(0, 'has_move')).to eq false
+        end
+
+        context 'hunter has the move' do
+          before { hunter.moves << move }
+
+          it 'display if the hunter has the move' do
+            subject
+            resp = JSON.parse(response.body)
+            expect(resp.dig(0, 'has_move')).to eq true
+          end
+        end
       end
     end
   end

--- a/spec/models/hunter_spec.rb
+++ b/spec/models/hunter_spec.rb
@@ -71,4 +71,20 @@ RSpec.describe Hunter, type: :model do
       it { is_expected.to eq false }
     end
   end
+
+  describe '#unstable?' do
+    subject { hunter.unstable? }
+
+    context 'hunter has more than 3 harm' do
+      let(:hunter) { create :hunter, harm: 4 }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'hunter has less than 3 harm' do
+      let(:hunter) { create :hunter, harm: 3 }
+
+      it { is_expected.to be_falsey }
+    end
+  end
 end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -5,6 +5,39 @@ require 'rails_helper'
 RSpec.describe Move, type: :model do
   let(:move) { create :moves_basic, rating: :cool }
 
+  describe '.with_hunter_moves' do
+    subject { Move.with_hunter_moves(hunter.id) }
+    let(:hunter) { create :hunter }
+    let(:hunters_move) { HuntersMove.first }
+    before { move }
+
+    context 'with hunter move' do
+      before { hunter.moves << move }
+
+      it 'includes hunter moves' do
+        expect(subject.pluck(:'hunters_moves.id', :'moves.id'))
+          .to include [hunters_move.id, move.id]
+      end
+    end
+
+    context 'without hunter move' do
+      it 'includes unclaimed moves' do
+        expect(subject.pluck(:'hunters_moves.id', :'moves.id'))
+          .to include [nil, move.id]
+      end
+    end
+
+    context 'unrelated hunter move' do
+      let(:unrelated_hunter) { create :hunter }
+      before { unrelated_hunter.moves << move }
+
+      it 'does not include other hunters hunters_moves' do
+        expect(subject.pluck(:'hunters_moves.id', :'moves.id'))
+          .not_to include [hunters_move.id, move.id]
+      end
+    end
+  end
+
   describe '#roll' do
     subject { move.roll(hunter) }
     let(:hunter) { create :hunter }


### PR DESCRIPTION
### Reason for Changes
The Edit page for Hunters will be an admin page where you can change anything about your hunter. Moves can be dynamically added and removed. This flexibility will support adding existing character without stepping through the character creation process. It will also support homebrew and keeper-approved moves. This flexibility is important in hunter management.

### Description of Changes
- Allow Users to Claim hunters that have no user
  - hunters can have no user if they've been seeded, or a user is deleted
- Fixed Hunter <=> Gear relation
- Show if the Hunter is Unstable (more than 3 harm)
- Get Moves by Hunter
- Add HunterMoves Component to add/remove moves on the hunter
- Modified Rails/UJS to allow Vue to submit forms