### PR TITLE
Rubocop excludes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rails
   - rubocop-rspec
 AllCops:
-  Excludes:
+  Exclude:
     - db/schema.rb
 
 Layout/EmptyLineAfterGuardClause:


### PR DESCRIPTION
At some point `excludes` was deprecated in favor of `exclude` in the Rubocop yaml file, and VS Code was yelling at me about it.  It still works if you don't change it; just a personal quality of life fix for me if it doesn't mess with anything on your end.