### PR TITLE
Customize Errors and Clean up Forms

### DIFF
--- a/app/controllers/hunters_improvements_controller.rb
+++ b/app/controllers/hunters_improvements_controller.rb
@@ -101,7 +101,7 @@ class HuntersImprovementsController < ApplicationController
   end
 
   def update_improvable_option
-    return unless @hunters_improvement.improvable
+    return if @hunters_improvement.improvable.blank?
     raw = if Array.try_convert(@hunters_improvement.improvable)
             @hunters_improvement.improvable.map do |option|
               JSON.parse(option)

--- a/app/controllers/improvements_controller.rb
+++ b/app/controllers/improvements_controller.rb
@@ -46,7 +46,7 @@ class ImprovementsController < ApplicationController
   def update
     respond_to do |format|
       if @improvement.update(improvement_params)
-        format.html { redirect_to @improvement, notice: 'Improvement was successfully updated.' }
+        format.html { redirect_to improvement_url(@improvement), notice: 'Improvement was successfully updated.' }
         format.json { render :show, status: :ok, location: @improvement }
       else
         format.html { render :edit }
@@ -74,6 +74,6 @@ class ImprovementsController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def improvement_params
-    params.require(:improvement).permit(:description, :type, :playbook_id, :rating, :stat_limit)
+    params.require(:improvement).permit(:advanced, :description, :type, :playbook_id, :rating, :stat_limit)
   end
 end

--- a/app/controllers/improvements_controller.rb
+++ b/app/controllers/improvements_controller.rb
@@ -46,7 +46,10 @@ class ImprovementsController < ApplicationController
   def update
     respond_to do |format|
       if @improvement.update(improvement_params)
-        format.html { redirect_to improvement_url(@improvement), notice: 'Improvement was successfully updated.' }
+        format.html do
+          redirect_to improvement_url(@improvement),
+                      notice: 'Improvement was successfully updated.'
+        end
         format.json { render :show, status: :ok, location: @improvement }
       else
         format.html { render :edit }
@@ -74,6 +77,8 @@ class ImprovementsController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def improvement_params
-    params.require(:improvement).permit(:advanced, :description, :type, :playbook_id, :rating, :stat_limit)
+    params.require(:improvement)
+      .permit(:advanced, :description, :type, :playbook_id, :rating,
+              :stat_limit)
   end
 end

--- a/app/controllers/improvements_controller.rb
+++ b/app/controllers/improvements_controller.rb
@@ -78,7 +78,7 @@ class ImprovementsController < ApplicationController
   # Never trust parameters from the scary internet, only allow the white list through.
   def improvement_params
     params.require(:improvement)
-      .permit(:advanced, :description, :type, :playbook_id, :rating,
-              :stat_limit)
+          .permit(:advanced, :description, :type, :playbook_id, :rating,
+                  :stat_limit)
   end
 end

--- a/app/helpers/playbooks_helper.rb
+++ b/app/helpers/playbooks_helper.rb
@@ -7,6 +7,8 @@ module PlaybooksHelper
   end
 
   def select_playbook(form)
-    form.collection_select :playbook_id, Playbook.all, :id, :name
+    tag.div class: 'select' do
+      form.collection_select :playbook_id, Playbook.all, :id, :name
+    end
   end
 end

--- a/app/models/hunter.rb
+++ b/app/models/hunter.rb
@@ -18,6 +18,7 @@ class Hunter < ApplicationRecord
   has_many :improvements, through: :hunters_improvements
   validates :harm, numericality: { less_than_or_equal_to: 7, greater_than_or_equal_to: 0 }
   validates :luck, numericality: { less_than_or_equal_to: MAX_LUCK, greater_than_or_equal_to: 0 }
+  validates_presence_of :charm, :cool, :sharp, :tough, :weird
 
   # List all improvements that are available
   # based on the hunter's playbook, and excludes

--- a/app/models/hunter.rb
+++ b/app/models/hunter.rb
@@ -18,7 +18,7 @@ class Hunter < ApplicationRecord
   has_many :improvements, through: :hunters_improvements
   validates :harm, numericality: { less_than_or_equal_to: 7, greater_than_or_equal_to: 0 }
   validates :luck, numericality: { less_than_or_equal_to: MAX_LUCK, greater_than_or_equal_to: 0 }
-  validates_presence_of :charm, :cool, :sharp, :tough, :weird
+  validates :charm, :cool, :sharp, :tough, :weird, presence: true
 
   # List all improvements that are available
   # based on the hunter's playbook, and excludes

--- a/app/views/gears/_form.html.erb
+++ b/app/views/gears/_form.html.erb
@@ -1,47 +1,49 @@
 <%= form_with(model: gear, local: true) do |form| %>
-  <% if gear.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(gear.errors.count, "error") %> prohibited this gear from being saved:</h2>
-
-      <ul>
-      <% gear.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-      </ul>
-    </div>
-  <% end %>
+  <%= render 'layouts/errors', errors: gear.errors %>
 
   <div class="field">
     <%= form.label :playbook_id %>
-    <%= select_playbook(form) %>
+    <div class="control">
+      <%= select_playbook(form) %>
+    </div>
   </div>
 
   <div class="field">
     <%= form.label :name %>
-    <%= form.text_field :name %>
+    <div class="control">
+      <%= form.text_field :name, class: 'input' %>
+    </div>
   </div>
 
   <div class="field">
     <%= form.label :description %>
-    <%= form.text_field :description %>
+    <div class="control">
+      <%= form.text_field :description, class: 'input' %>
+    </div>
   </div>
 
   <div class="field">
     <%= form.label :harm %>
-    <%= form.number_field :harm %>
+    <div class="control">
+      <%= form.number_field :harm, class: 'input' %>
+    </div>
   </div>
 
   <div class="field">
     <%= form.label :armor %>
-    <%= form.number_field :armor %>
+    <div class="control">
+      <%= form.number_field :armor, class: 'input' %>
+    </div>
   </div>
 
   <div>
     <%= form.label :tag_list %>
-    <%= form.text_field :tag_list %>
+    <div class="control">
+      <%= form.text_field :tag_list, class: 'input' %>
+    </div>
   </div>
-
+  <br />
   <div class="actions">
-    <%= form.submit %>
+    <%= form.submit class: 'button is-primary' %>
   </div>
 <% end %>

--- a/app/views/hunters/_form.html.erb
+++ b/app/views/hunters/_form.html.erb
@@ -1,68 +1,79 @@
 <%= form_with(model: hunter, local: true) do |form| %>
-  <% if hunter.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(hunter.errors.count, "error") %> prohibited this hunter from being saved:</h2>
+  <%= render 'layouts/errors', errors: hunter.errors %>
 
-      <ul>
-      <% hunter.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-      </ul>
-    </div>
-  <% end %>
   <section>
     <div class="field">
       <%= form.label :name %>
-      <%= form.text_field :name %>
+      <div class="control">
+        <%= form.text_field :name, class: 'input' %>
+      </div>
     </div>
 
     <div class="field">
       <%= form.label :playbook %>
-      <%= select_playbook(form) %>
+      <div class="control">
+        <%= select_playbook(form) %>
+      </div>
     </div>
 
     <div class="field">
       <%= form.label :harm %>
-      <%= form.number_field :harm %>
+      <div class="control">
+        <%= form.number_field :harm, class: 'input' %>
+      </div>
     </div>
 
     <div class="field">
       <%= form.label :luck %>
-      <%= form.number_field :luck %>
+      <div class="control">
+        <%= form.number_field :luck, class: 'input' %>
+      </div>
     </div>
 
     <div class="field">
       <%= form.label :experience %>
-      <%= form.number_field :experience %>
+      <div class="control">
+        <%= form.number_field :experience, class: 'input' %>
+      </div>
     </div>
 
     <div class="field">
       <%= form.label :charm %>
-      <%= form.number_field :charm %>
+      <div class="control">
+        <%= form.number_field :charm, class: 'input' %>
+      </div>
     </div>
 
     <div class="field">
       <%= form.label :cool %>
-      <%= form.number_field :cool %>
+      <div class="control">
+        <%= form.number_field :cool, class: 'input' %>
+      </div>
     </div>
 
     <div class="field">
       <%= form.label :sharp %>
-      <%= form.number_field :sharp %>
+      <div class="control">
+        <%= form.number_field :sharp, class: 'input' %>
+      </div>
     </div>
 
     <div class="field">
       <%= form.label :tough %>
-      <%= form.number_field :tough %>
+      <div class="control">
+        <%= form.number_field :tough, class: 'input' %>
+      </div>
     </div>
 
     <div class="field">
       <%= form.label :weird %>
-      <%= form.number_field :weird %>
+      <div class="control">
+        <%= form.number_field :weird, class: 'input' %>
+      </div>
     </div>
   </section>
 
   <div class="actions">
-    <%= form.submit %>
+    <%= form.submit class: 'button is-primary' %>
   </div>
 <% end %>

--- a/app/views/hunters_improvements/_form.html.erb
+++ b/app/views/hunters_improvements/_form.html.erb
@@ -1,17 +1,5 @@
 <%= form_with(model: [hunters_improvement.hunter, hunters_improvement], local: true) do |form| %>
-  <% if hunters_improvement.errors.any? %>
-    <b-notification
-      type="is-danger"
-      aria-close-label="Close notification"
-      role="alert">
-      <h4><%= pluralize(hunters_improvement.errors.count, "error") %> prohibited this hunters_improvement from being saved:</h4>
-      <ul>
-        <% hunters_improvement.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </b-notification>
-  <% end %>
+  <%= render 'layouts/errors', errors: hunters_improvement.errors %>
 
   <hunters-improvement-form hunter_id="<%= hunters_improvement.hunter.id %>" :improvements="<%= @improvements.to_json %>"></hunters-improvement-form>
 

--- a/app/views/improvements/_form.html.erb
+++ b/app/views/improvements/_form.html.erb
@@ -1,43 +1,52 @@
 <%= form_with(model: improvement.becomes(Improvement), local: true) do |form| %>
   <% form.object = improvement.becomes(improvement.class) %>
-  <% if improvement.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(improvement.errors.count, "error") %> prohibited this improvement from being saved:</h2>
-
-      <ul>
-      <% improvement.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-      </ul>
-    </div>
-  <% end %>
+  <%= render 'layouts/errors', errors: improvement.errors %>
 
   <div class="field">
     <%= form.label :playbook %>
-    <%= form.collection_select :playbook_id, Playbook.all, :id, :name %>
+    <div class="control">
+      <%= select_playbook(form) %>
+    </div>
+  </div>
+
+  <div class="field">
+     <%= form.label :advanced %>
+    <%= form.check_box :advanced %>
   </div>
 
   <div class="field">
     <%= form.label :description %>
-    <%= form.text_field :description %>
+    <div class="control">
+      <%= form.text_field :description, class: 'input' %>
+    </div>
   </div>
 
   <div class="field">
     <%= form.label :type %>
-    <%= form.select(:type, Improvement::IMPROVEMENT_TYPES) %>
+    <div class="control">
+      <div class="select">
+        <%= form.select(:type, Improvement::IMPROVEMENT_TYPES) %>
+      </div>
+    </div>
   </div>
 
   <div class="field">
     <%= form.label :rating %>
-    <%= form.select(:rating, Improvement.ratings.keys) %>
+    <div class="control">
+      <div class="select">
+        <%= form.select(:rating, Improvement.ratings.keys, include_blank: true) %>
+      </div>
+    </div>
   </div>
 
   <div class="field">
     <%= form.label :stat_limit %>
-    <%= form.number_field :stat_limit %>
+    <div class="control">
+      <%= form.number_field :stat_limit, class: 'input' %>
+    </div>
   </div>
 
   <div class="actions">
-    <%= form.submit %>
+    <%= form.submit class: 'button is-primary' %>
   </div>
 <% end %>

--- a/app/views/improvements/_improvement.json.jbuilder
+++ b/app/views/improvements/_improvement.json.jbuilder
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
-json.extract! improvement, :id, :description, :type, :rating, :stat_limit, :advanced, :created_at, :updated_at
+json.extract! improvement,
+  :id, :description, :type, :rating, :stat_limit, :advanced,
+  :created_at, :updated_at
 json.url improvement_url(improvement, format: :json)

--- a/app/views/improvements/_improvement.json.jbuilder
+++ b/app/views/improvements/_improvement.json.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 json.extract! improvement,
-  :id, :description, :type, :rating, :stat_limit, :advanced,
-  :created_at, :updated_at
+              :id, :description, :type, :rating, :stat_limit, :advanced,
+              :created_at, :updated_at
 json.url improvement_url(improvement, format: :json)

--- a/app/views/improvements/_improvement.json.jbuilder
+++ b/app/views/improvements/_improvement.json.jbuilder
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-json.extract! improvement, :id, :description, :type, :rating, :stat_limit, :created_at, :updated_at
+json.extract! improvement, :id, :description, :type, :rating, :stat_limit, :advanced, :created_at, :updated_at
 json.url improvement_url(improvement, format: :json)

--- a/app/views/layouts/_errors.html.erb
+++ b/app/views/layouts/_errors.html.erb
@@ -1,0 +1,10 @@
+<% if errors.any? %>
+  <b-message type="is-danger">
+    <h2><%= pluralize(errors.count, "error") %> prohibited this from being saved:</h2>
+    <ul>
+      <% errors.full_messages.each do |error| %>
+        <li><%= error %></li>
+      <% end %>
+    </ul>
+  </b-message>
+<% end %>

--- a/app/views/layouts/_errors.html.erb
+++ b/app/views/layouts/_errors.html.erb
@@ -1,5 +1,7 @@
 <% if errors.any? %>
-  <b-message type="is-danger">
+  <b-message type="is-danger"
+             aria-close-label="Close notification"
+             role="alert">
     <h2><%= pluralize(errors.count, "error") %> prohibited this from being saved:</h2>
     <ul>
       <% errors.full_messages.each do |error| %>

--- a/config/initializers/customize_error.rb
+++ b/config/initializers/customize_error.rb
@@ -1,0 +1,12 @@
+ActionView::Base.field_error_proc = Proc.new do |html_tag, instance|
+  class_attr_index = html_tag.index 'class="'
+  label = html_tag.index 'label'
+
+  if label
+    html_tag
+  elsif class_attr_index
+    html_tag.insert class_attr_index + 7, 'is-danger '
+  else
+    "<div class=\"field_with_errors\">#{html_tag}</div>".html_safe
+  end
+end

--- a/spec/controllers/hunters_controller_spec.rb
+++ b/spec/controllers/hunters_controller_spec.rb
@@ -12,7 +12,12 @@ RSpec.describe HuntersController, type: :controller do
         name: 'Ruudii',
         playbook_id: create(:playbook).id,
         harm: 0,
-        luck: 0
+        luck: 0,
+        charm: 1,
+        cool: 1,
+        sharp: 0,
+        tough: -1,
+        weird: 0
       }
     }
   end


### PR DESCRIPTION
## Description
closes #72
We want to use Bulma's native error presentation to make our error messages more attractive and pleasant.

## Solution
We overwrote the Rails' `field_error_proc` to apply bulma styling if there is a class on the div (which there will be if Bulma is used on the input). Labels get no styling anymore. Original styling is applied if there are no classes on the field.
- Updated Gear form
- Updated Hunter form
- Updated HunterImprovement form
- Updated Improvement Form