### PR TITLE
Fix issue with Improvements::AdvancedMove

### DIFF
--- a/app/javascript/components/hunters_improvement_form.vue
+++ b/app/javascript/components/hunters_improvement_form.vue
@@ -1,13 +1,17 @@
 <template>
   <section>
     <b-field label="Improvements">
-      <b-select @input="selectImprovement(improvement)" v-model="improvement" placeholder="Select an Improvement" name="hunters_improvement[improvement_id]">
+      <b-select
+        @input="selectImprovement(improvement)"
+        v-model="improvement"
+        placeholder="Select an Improvement"
+        name="hunters_improvement[improvement_id]"
+      >
         <option
           v-for="improvement in improvements"
           :value="improvement.id"
-          :key="improvement.id">
-            {{ improvement.description }}
-        </option>
+          :key="improvement.id"
+        >{{ improvement.description }}</option>
       </b-select>
     </b-field>
     <b-field v-if="options.length > 0" label="Options" v-bind:message="optionDescription">
@@ -19,14 +23,19 @@
         <b-dropdown-item
           v-for="option in options"
           :value="stringifyValue(option)"
-          :key="optionKey(option)">
-            {{ displayOption(option) }}
-        </b-dropdown-item>
+          :key="optionKey(option)"
+        >{{ displayOption(option) }}</b-dropdown-item>
       </b-dropdown>
     </b-field>
     <span v-if="multiple">
-      <input  type="hidden" v-for="option in selectedOptions" name="hunters_improvement[improvable][]" :value="option" />
-    </span><span v-else>
+      <input
+        type="hidden"
+        v-for="option in selectedOptions"
+        name="hunters_improvement[improvable][]"
+        :value="option"
+      />
+    </span>
+    <span v-else>
       <input type="hidden" name="hunters_improvement[improvable]" :value="selectedOptions" />
     </span>
   </section>
@@ -35,42 +44,42 @@
 <script>
 export default {
   computed: {
-    multiple: function(){
+    multiple: function() {
       return this.optionsCount > 1;
     },
-    optionDescription: function () {
+    optionDescription: function() {
       if (!this.selectedOptions) {
-        return '';
+        return "";
       }
-      if (this.multiple && this.selectedOptions.length > 1)
-      {
-        return '';
+      if (this.multiple && this.selectedOptions.length > 1) {
+        return "";
       } else {
         let option = JSON.parse(this.selectedOptions);
         return option.description;
       }
     },
-    selectedDisplay: function () {
+    selectedDisplay: function() {
       if (!this.selectedOptions) {
         return `Select {this.optionsCount}`;
       }
-      if (this.multiple && this.selectedOptions.length > 1)
-      {
-        this.selectedNames = this.selectedOptions.map((option) => JSON.parse(option).name);
-        return this.selectedNames.join(', ');
+      if (this.multiple && this.selectedOptions.length > 1) {
+        this.selectedNames = this.selectedOptions.map(
+          option => JSON.parse(option).name
+        );
+        return this.selectedNames.join(", ");
       } else {
         let option = JSON.parse(this.selectedOptions);
         return option.name ? option.name : option.improvable;
       }
     }
   },
-  data: function () {
+  data: function() {
     return {
       improvement: {},
       selectedOptions: [],
       options: [],
-      optionsCount: 0,
-    }
+      optionsCount: 0
+    };
   },
   methods: {
     displayOption(option) {
@@ -80,11 +89,13 @@ export default {
       return option.id ? option.id : option;
     },
     selectImprovement(improvement) {
-      fetch(`/improvements/${this.improvement}.json?hunter_id=${this.hunter_id}`)
+      fetch(
+        `/improvements/${this.improvement}.json?hunter_id=${this.hunter_id}`
+      )
         .then(response => response.json())
-        .then((improvement) => {
-          this.options = improvement['improvable_options'];
-          this.optionsCount = improvement['options_count'];
+        .then(improvement => {
+          this.options = improvement["improvable_options"];
+          this.optionsCount = improvement["options_count"];
           if (this.options) {
             this.selectedOptions = [this.stringifyValue(this.options[0])];
           }
@@ -95,11 +106,11 @@ export default {
         if (option.id) {
           return JSON.stringify(option);
         } else {
-          return JSON.stringify({ 'improvable': option });
+          return JSON.stringify({ improvable: option });
         }
       }
-    },
+    }
   },
-  props: ['hunter_id', 'improvements']
-}
+  props: ["hunter_id", "improvements"]
+};
 </script>

--- a/app/models/hunter.rb
+++ b/app/models/hunter.rb
@@ -45,12 +45,20 @@ class Hunter < ApplicationRecord
     save
   end
 
+  # Returns the Hunters Move otherwise known as the object
+  # that represents the relationship between the hunter and the move.
+  #
+  # @param move_id [Move_id] the if of the move
+  def hunters_move_for(move_id:)
+    hunters_moves.find_by(move_id: move_id)
+  end
+
   # Check whether a move has been advanced by an improvement
   # for this hunter
   #
   # @param move [Move] the move to check
   def advanced?(move)
-    !!(hunters_moves.find_by(move: move)&.advanced)
+    !!(hunters_move_for(move_id: move.id)&.advanced)
   end
 
   # Check whether the hunter has lost enough health to fall unstable

--- a/app/models/improvements/advanced_move.rb
+++ b/app/models/improvements/advanced_move.rb
@@ -12,18 +12,24 @@ module Improvements
 
     def add_errors(hunters_improvement)
       super(hunters_improvement)
-      validate_hunter hunters_improvement
       validate_improvable hunters_improvement
+      validate_hunter hunters_improvement if hunters_improvement.errors.blank?
       hunters_improvement.errors.present?
     end
 
     def validate_improvable(hunters_improvement)
-      return if only_2_moves?(hunters_improvement)
-      hunters_improvement.errors.add(:improvable, 'does not have 2 moves')
+      unless only_2_moves?(hunters_improvement)
+        hunters_improvement.errors.add(:improvable, 'does not have 2 moves')
+      end
+      return if basic_moves?(hunters_improvement)
+      hunters_improvement.errors.add(:improvable, 'moves are not basic.')
     end
 
     def validate_hunter(hunters_improvement)
-      hunters_moves(hunters_improvement).each do |hunters_move|
+      move_ids(hunters_improvement).each do |move_id|
+        hunters_move = hunters_improvement.hunter
+                                          .hunters_moves
+                                          .find_or_create_by(move_id: move_id)
         next unless hunters_move.advanced
         hunters_improvement
           .errors
@@ -31,21 +37,32 @@ module Improvements
       end
     end
 
+    def basic_moves?(hunters_improvement)
+      move_ids = move_ids(hunters_improvement)
+      Moves::Basic.where(id: move_ids).count == move_ids.count
+    end
+
     def only_2_moves?(hunters_improvement)
-      hunters_moves(hunters_improvement).count == 2
+      move_ids(hunters_improvement).count == 2
     end
 
     def hunters_moves(hunters_improvement)
       @hunters_moves ||= hunters_improvement
                          .hunter
                          .hunters_moves
-                         .where(move_id: hunters_improvement.improvable.pluck('id'))
+                         .where(move_id: move_ids(hunters_improvement))
+    end
+
+    def move_ids(hunters_improvement)
+      hunters_improvement.improvable.pluck('id')
     end
 
     def improvable_options(hunter)
-      Moves::Basic.joins(:hunters_moves)
-                  .where(hunters_moves: { hunter_id: hunter.id, advanced: [false, nil] })
-                  .select(:id, :name, :description)
+      Moves::Basic
+        .joins("LEFT JOIN hunters_moves ON moves.id = hunters_moves.move_id \
+                  AND hunter_id = #{hunter.id}")
+        .where(hunters_moves: { advanced: [false, nil] })
+        .select(:'moves.id', :name, :description)
     end
 
     def options_count

--- a/spec/models/improvements/advanced_move_spec.rb
+++ b/spec/models/improvements/advanced_move_spec.rb
@@ -10,10 +10,11 @@ RSpec.describe Improvements::AnotherMove, type: :model do
           improvement: advanced_move,
           improvable: improvable
   end
-  let(:improvable) { [{'id': move.id, 'name': move.name, 'description': move.description }, {'id': move2.id, 'name': move2.name, 'description': move2.description }] }
-  let(:hunter) { create :hunter, playbook: advanced_move.playbook  }
+  let(:improvable) { [{ 'id': move.id, 'name': move.name, 'description': move.description }, { 'id': move2.id, 'name': move2.name, 'description': move2.description }] }
+  let(:hunter) { create :hunter, playbook: advanced_move.playbook }
   let(:move) { create :moves_basic }
   let(:move2) { create :moves_basic }
+
   before { hunter.moves << [move, move2] }
 
   describe '#apply' do
@@ -26,7 +27,7 @@ RSpec.describe Improvements::AnotherMove, type: :model do
     it { is_expected.to be_truthy }
 
     context 'one move' do
-      let(:improvable) { [{'id': move.id, 'name': move.name, 'description': move.description }] }
+      let(:improvable) { [{ 'id': move.id, 'name': move.name, 'description': move.description }] }
 
       it { is_expected.to be_falsey }
 
@@ -38,6 +39,7 @@ RSpec.describe Improvements::AnotherMove, type: :model do
 
     context 'hunter has already advanced move' do
       before { hunter.hunters_moves.find_by(move: move).update(advanced: true) }
+
       it { is_expected.to be_falsey }
 
       it 'appends errors to hunters_improvement' do
@@ -47,11 +49,25 @@ RSpec.describe Improvements::AnotherMove, type: :model do
     end
   end
 
+  describe '#basic_moves?' do
+    subject { advanced_move.basic_moves?(hunters_improvement) }
+
+    context 'both moves are basic moves' do
+      it { is_expected.to be_truthy }
+    end
+
+    context 'one move is not basic' do
+      let(:move) { create :moves_descriptive }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+
   describe '#hunters_moves' do
     subject { advanced_move.hunters_moves(hunters_improvement) }
 
-    it 'should return moves from the hunter' do
-      is_expected.to include(hunter.hunters_moves.find_by(move: move))
+    it 'returns moves from the hunter' do
+      expect(subject).to include(hunter.hunters_moves.find_by(move: move))
     end
   end
 
@@ -65,6 +81,20 @@ RSpec.describe Improvements::AnotherMove, type: :model do
       before { hunter.hunters_moves.find_by(move: move).update(advanced: true) }
 
       it { is_expected.not_to include(move) }
+    end
+
+    context 'hunter does not have move yet' do
+      before { hunter.moves = [] }
+
+      let!(:basic_move) { create :moves_basic }
+
+      it { is_expected.to include(move) }
+
+      it 'includes all basic moves' do
+        expect(hunter.moves.count).to eq 0
+        expect(hunter.hunters_moves.count).to eq 0
+        expect(subject.count(1)).to eq Moves::Basic.count
+      end
     end
   end
 


### PR DESCRIPTION
AdvancedMove marks two hunters moves that are Moves::Basic as Advanced. However, hunters do not have hunter_moves for Moves::Basic upon creation.
All hunter have access to Moves::Basic, and can roll them through their character sheet, but they may not be stored in hunters_moves.

This commit:
* adds Basic Moves to improvable_options even if the hunter doesn't have them
* creates hunter_moves if the hunter has selected them and does not have them
* check that all moves are basic, before giving them to the hunter
* Surprise linting courtesy of VS Code