### PR TITLE
Remove Sassc from application header

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,6 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_pack_tag 'application' %>
   </head>


### PR DESCRIPTION
Remove Sassc from the application by removing the application header that's expecting it.
Sassc relies on several C libraries that are often difficult to load in Linux environments. We don't use Sass, so we should remove it.