### PR TITLE
Fix Responsive Mobile Issue

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_pack_tag 'application' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_pack_tag 'application' %>
   </head>
@@ -36,9 +37,7 @@
           <%= alert %>
         </b-message>
       <% end %>
-      <section>
-        <%= yield %>
-      </section>
+      <%= yield %>
     </div>
   </body>
 </html>


### PR DESCRIPTION
# Description
Mobile view of HK was showing 3 columns horizontally instead of 1 column vertically. We needed to add the viewport meta tag so the app understands the size of the page we're building.

Bonus: We defined the charset for the app (utf-8)

# Resources
- [Responsive Meta tags](https://www.w3schools.com/css/css_rwd_viewport.asp)
- [Further reading on viewport meta tags](https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag)