### PR TITLE
fixed include matcher issue

### DIFF
--- a/spec/controllers/hunters_improvements_controller_spec.rb
+++ b/spec/controllers/hunters_improvements_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe HuntersImprovementsController, type: :controller do
   # HuntersImprovementsController. Be sure to keep this updated too.
   let(:valid_session) { {} }
 
-  before(:each) do
+  before do
     @request.env['devise.mapping'] = Devise.mappings[:user]
     sign_in create(:user)
   end
@@ -65,6 +65,7 @@ RSpec.describe HuntersImprovementsController, type: :controller do
 
   describe 'GET #edit' do
     subject { get :edit, params: { hunter_id: hunter.id, id: hunters_improvement.to_param }, session: valid_session }
+
     it 'returns a success response' do
       subject
       expect(response).to be_successful
@@ -146,7 +147,7 @@ RSpec.describe HuntersImprovementsController, type: :controller do
         it 'send errors in our json response' do
           subject
           resp = JSON.parse(response.body)
-          expect(resp['hunter']).to include 'does not match improvement playbook: '
+          expect(resp['hunter']).to include 'does not match improvement playbook: The Unspecified'
         end
       end
     end
@@ -154,6 +155,7 @@ RSpec.describe HuntersImprovementsController, type: :controller do
 
   describe 'PUT #update' do
     subject { put :update, params: { hunter_id: hunter.id, id: hunters_improvement.id, hunters_improvement: attributes }, session: valid_session, format: format_type }
+
     let(:different_improvement) { create(:improvement) }
 
     context 'with valid params' do


### PR DESCRIPTION
### Issue:
The test checking to see if the JSON response included errors when passed invalid params was failing despite actually containing the text it was attempting to check.

### Cause:
The test was attempting to check an array with one index point, not the string contained within that index point, so the matcher needed an exact match to an index point to see if it was included since each entire index point is being compared.

### Solution
Edited the include matcher to exactly match what the index point should include.  Conversely, if we did want it to include the ability to have differently named playbooks, we could convert the array into a string, e.g. `expect(resp['hunter'].to_s).to include 'does not match improvement playbook: '`