### PR TITLE
Changed name of move in column to be a link_to to reduce move size

### DIFF
--- a/app/views/moves/index.html.erb
+++ b/app/views/moves/index.html.erb
@@ -14,9 +14,8 @@
     <% @moves.each do |move| %>
       <tr>
         <td><%= link_to_playbook(move) %></td>
-        <td><%= move.name %></td>
+        <td><%= link_to_move(move) %></td>
         <td><%= move.rating %></td>
-        <td><%= link_to 'Show', move_path(move) %></td>
         <td><%= link_to 'Edit', edit_move_path(move) %></td>
         <td><%= link_to 'Destroy', move_path(move), method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>

--- a/app/views/moves/index.html.erb
+++ b/app/views/moves/index.html.erb
@@ -6,7 +6,7 @@
       <th>Playbook</th>
       <th>Name</th>
       <th>Rating</th>
-      <th colspan="3"></th>
+      <th colspan="2"></th>
     </tr>
   </thead>
 


### PR DESCRIPTION
Closes [130](https://github.com/ChaelCodes/HuntersKeepers/issues/130)

### Description
Shrinking the size of the Moves table by linking to the move on the move name and removing the Show column.

**Before:**
![image](https://user-images.githubusercontent.com/20643587/84591689-5e32a380-ae38-11ea-8799-9557b643c044.png)

**After:** 
![image](https://user-images.githubusercontent.com/20643587/84591773-fa5caa80-ae38-11ea-85e1-ae16db49fd62.png)


### Solution
Moved the Show move table column and changed the move name to be a link_to.
It appears the _link_to_move_ had already been implemented in the _moves_helper_ :smiley: 