### PR TITLE
Removed references to 'white list' and replace with 'allow list.'

### DIFF
--- a/app/controllers/gears_controller.rb
+++ b/app/controllers/gears_controller.rb
@@ -70,7 +70,8 @@ class GearsController < ApplicationController
     @gear = Gear.find(params[:id])
   end
 
-  # Never trust parameters from the scary internet, only allow the white list through.
+  # Never trust parameters from the scary internet,
+  # only permit the allow list through.
   def gear_params
     params.require(:gear).permit(:name, :description, :harm, :armor, :playbook_id, :tag_list)
   end

--- a/app/controllers/hunters_improvements_controller.rb
+++ b/app/controllers/hunters_improvements_controller.rb
@@ -112,7 +112,8 @@ class HuntersImprovementsController < ApplicationController
     @hunters_improvement.improvable = raw
   end
 
-  # Never trust parameters from the scary internet, only allow the white list through.
+  # Never trust parameters from the scary internet,
+  # only permit the allow list through.
   def hunters_improvement_params
     params.require(:hunters_improvement)
           .permit(:hunter_id, :improvement_id, :improvable, improvable: [])

--- a/app/controllers/improvements_controller.rb
+++ b/app/controllers/improvements_controller.rb
@@ -75,7 +75,8 @@ class ImprovementsController < ApplicationController
     @improvement = Improvement.find(params[:id])
   end
 
-  # Never trust parameters from the scary internet, only allow the white list through.
+  # Never trust parameters from the scary internet,
+  # only permit the allow list through.
   def improvement_params
     params.require(:improvement)
           .permit(:advanced, :description, :type, :playbook_id, :rating,

--- a/app/controllers/moves_controller.rb
+++ b/app/controllers/moves_controller.rb
@@ -86,7 +86,8 @@ class MovesController < ApplicationController
     @move = Move.find(params[:id])
   end
 
-  # Never trust parameters from the scary internet, only allow the white list through.
+  # Never trust parameters from the scary internet,
+  # only permit the allow list through.
   def move_params
     params.require(:move).permit(:playbook_id,
                                  :type,

--- a/app/controllers/playbooks_controller.rb
+++ b/app/controllers/playbooks_controller.rb
@@ -69,7 +69,8 @@ class PlaybooksController < ApplicationController
     @playbook = Playbook.find(params[:id])
   end
 
-  # Never trust parameters from the scary internet, only allow the white list through.
+  # Never trust parameters from the scary internet,
+  # only permit the allow list through.
   def playbook_params
     params.require(:playbook).permit(:name, :description)
   end

--- a/app/controllers/ratings_controller.rb
+++ b/app/controllers/ratings_controller.rb
@@ -69,7 +69,8 @@ class RatingsController < ApplicationController
     @rating = Rating.find(params[:id])
   end
 
-  # Never trust parameters from the scary internet, only allow the white list through.
+  # Never trust parameters from the scary internet,
+  # only permit the allow list through.
   def rating_params
     params.require(:rating).permit(:playbook_id, :charm, :cool, :sharp, :tough, :weird)
   end


### PR DESCRIPTION
One of the most requested small changes I've seen to increase inclusion in the development space is deprecation of the terms 'white list' and 'black list' in favor of 'allow list' and 'block/deny list.'  Since we had references in our documentation, I changed them.