### PR TITLE
BAN USERS

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,21 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+  devise :database_authenticatable,
+         :registerable, :recoverable, :rememberable,
+         :validatable
+  validates :email, uniqueness: true
+
+  def ban!
+    raise 'User has already been Banned' if banned?
+    update!(banned_at: Time.zone.now)
+  end
+
+  def banned?
+    banned_at.present?
+  end
+
+  def active_for_authentication?
+    super && !banned?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,9 +18,9 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable,
-         :registerable, :recoverable, :rememberable,
-         :validatable
+  devise :confirmable, :database_authenticatable,
+         :recoverable, :registerable,
+         :rememberable, :validatable
   validates :email, uniqueness: true
 
   def ban!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,6 +33,7 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
+  config.action_mailer.perform_deliveries = false
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,6 +64,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.default_url_options = { host: 'http://hunters-keepers.herokuapp.com' }
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -18,13 +18,13 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'no-reply@hunters-keepers.herokuapp.com'
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.mailer = 'Devise::Mailer'
 
   # Configure the parent class responsible to send e-mails.
-  # config.parent_mailer = 'ActionMailer::Base'
+  config.parent_mailer = 'ActionMailer::Base'
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -131,7 +131,7 @@ Devise.setup do |config|
   # without confirming their account.
   # Default is 0.days, meaning the user cannot access the website without
   # confirming their account.
-  # config.allow_unconfirmed_access_for = 2.days
+  config.allow_unconfirmed_access_for = 10.years if Rails.env.development?
 
   # A period that the user is allowed to confirm their account before their
   # token becomes invalid. For example, if set to 3.days, the user can confirm

--- a/config/initializers/smtp.rb
+++ b/config/initializers/smtp.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+ActionMailer::Base.smtp_settings = {
+  domain: 'hunters-keepers.herokuapp.com',
+  address: 'smtp.sendgrid.net',
+  port: 587,
+  authentication: :plain,
+  user_name: 'apikey',
+  password: ENV['SENDGRID_API_KEY']
+}

--- a/db/migrate/20200621132924_add_security_to_users.rb
+++ b/db/migrate/20200621132924_add_security_to_users.rb
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
+
 class AddSecurityToUsers < ActiveRecord::Migration[6.0]
   def change
     add_column :users, :banned_at, :datetime
-    add_column :users, :confirmed_at, :datetime
   end
 end

--- a/db/migrate/20200621132924_add_security_to_users.rb
+++ b/db/migrate/20200621132924_add_security_to_users.rb
@@ -1,0 +1,6 @@
+class AddSecurityToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :banned_at, :datetime
+    add_column :users, :confirmed_at, :datetime
+  end
+end

--- a/db/migrate/20200621150901_add_confirmable_to_devise.rb
+++ b/db/migrate/20200621150901_add_confirmable_to_devise.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddConfirmableToDevise < ActiveRecord::Migration[6.0]
+  # Note: You can't use change, as User.update_all will fail in the down migration
+  def up
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+    add_column :users, :unconfirmed_email, :string # Only if using reconfirmable
+    add_index :users, :confirmation_token, unique: true
+  end
+
+  def down
+    remove_columns :users, :confirmation_token, :confirmed_at, :confirmation_sent_at
+    remove_columns :users, :unconfirmed_email # Only if using reconfirmable
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_09_183512) do
+ActiveRecord::Schema.define(version: 2020_06_21_132924) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -147,6 +147,8 @@ ActiveRecord::Schema.define(version: 2020_02_09_183512) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "admin"
+    t.datetime "banned_at"
+    t.datetime "confirmed_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_21_132924) do
+ActiveRecord::Schema.define(version: 2020_06_21_150901) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -148,7 +148,11 @@ ActiveRecord::Schema.define(version: 2020_06_21_132924) do
     t.datetime "updated_at", null: false
     t.boolean "admin"
     t.datetime "banned_at"
+    t.string "confirmation_token"
     t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/seeds/development/user.seeds.rb
+++ b/db/seeds/development/user.seeds.rb
@@ -3,7 +3,8 @@
 [
   {
     email: 'test@example.com',
-    password: SecureRandom.base64(12)
+    password: SecureRandom.base64(12),
+    confirmed_at: Time.zone.now
   }
 ].each do |user|
   User.find_or_initialize_by(email: user[:email]).update!(user)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -20,8 +20,18 @@ FactoryBot.define do
       "lala_#{i}@example.com"
     end
     password { '12345678' }
+    confirmed_at { Time.zone.now }
+
     trait :admin do
       admin { true }
+    end
+
+    trait :banned do
+      banned_at { Time.zone.now }
+    end
+
+    trait :unconfirmed do
+      confirmed_at { nil }
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: users
@@ -15,5 +17,43 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:user) { create :user }
+
+  describe '#banned?' do
+    subject { user.banned? }
+
+    it { is_expected.to be_falsey }
+
+    context 'banned user' do
+      let(:user) { create :user, :banned }
+
+      it { is_expected.to be_truthy }
+    end
+  end
+
+  describe '#ban!' do
+    subject { user.ban! }
+
+    it { expect { subject }.to change(user, :banned?).from(false).to(true) }
+
+    context 'banned user' do
+      let(:user) { create(:user, :banned) }
+
+      it 'warns the admin of a banned user' do
+        expect { subject }.to raise_error('User has already been Banned')
+      end
+    end
+  end
+
+  describe '#active_for_authentication?' do
+    subject { user.active_for_authentication? }
+
+    it { is_expected.to be_truthy }
+
+    context 'banned user' do
+      let(:user) { create :user, :banned }
+
+      it { is_expected.to be_falsey }
+    end
+  end
 end


### PR DESCRIPTION
closes #140 

## Description
We need the ability to ban users from HuntersKeepers.

We'll implement the confirmable module from devise, and we'll add the ability to ban users from the rails console. When users are banned, their account is immediately inactive, and cannot be used to create new data. We're also going to require email confirmation, so people can't use fake emails.

Developers will still be able to access without email confirmation because we're setting the delay to 10 years in development.