### PR TITLE
Optimize Controller Specs - linting, Devise

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,13 @@ Metrics/BlockLength:
 Rails/RequestReferer:
   EnforcedStyle: referrer
 
+RSpec/ExampleLength:
+  Max: 10
+
 RSpec/HookArgument:
+  Enabled: false
+
+RSpec/ImplicitSubject:
   Enabled: false
 
 RSpec/LetSetup:
@@ -27,4 +33,7 @@ RSpec/MultipleExpectations:
     - spec/views/**/*
 
 RSpec/NestedGroups:
+  Enabled: false
+
+Style/DoubleNegation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,22 @@ AllCops:
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 
+Metrics/BlockLength:
+  Exclude: 
+    - 'spec/**/*'
+
 Rails/RequestReferer:
   EnforcedStyle: referrer
-  
+
+RSpec/HookArgument:
+  Enabled: false
+
+RSpec/LetSetup:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Exclude:
+    - spec/views/**/*
+
+RSpec/NestedGroups:
+  Enabled: false

--- a/spec/controllers/gears_controller_spec.rb
+++ b/spec/controllers/gears_controller_spec.rb
@@ -1,130 +1,148 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe GearsController, type: :controller do
-
   # This should return the minimal set of attributes required to create a valid
   # Gear. As you add validations to Gear, be sure to
   # adjust the attributes here as well.
-  let(:valid_attributes) {
+  let(:valid_attributes) do
     {
       playbook_id: create(:playbook).id,
       name: 'Gear'
     }
-  }
+  end
 
-  let(:invalid_attributes) {
+  let(:invalid_attributes) do
     {
       name: ''
     }
-  }
+  end
 
   # This should return the minimal set of values that should be in the session
   # in order to pass any filters (e.g. authentication) defined in
   # GearsController. Be sure to keep this updated too.
   let(:valid_session) { {} }
 
-  before(:each) do
-    @request.env["devise.mapping"] = Devise.mappings[:user]
-    sign_in create(:user)
+  let(:user) { create :user }
+
+  before do
+    sign_in user
   end
 
-  describe "GET #index" do
-    it "returns a success response" do
+  describe 'GET #index' do
+    it 'returns a success response' do
       Gear.create! valid_attributes
       get :index, params: {}, session: valid_session
       expect(response).to be_successful
     end
   end
 
-  describe "GET #show" do
-    it "returns a success response" do
+  describe 'GET #show' do
+    it 'returns a success response' do
       gear = Gear.create! valid_attributes
-      get :show, params: {id: gear.to_param}, session: valid_session
+      get :show, params: { id: gear.to_param }, session: valid_session
       expect(response).to be_successful
     end
   end
 
-  describe "GET #new" do
-    it "returns a success response" do
+  describe 'GET #new' do
+    it 'returns a success response' do
       get :new, params: {}, session: valid_session
       expect(response).to be_successful
     end
   end
 
-  describe "GET #edit" do
-    it "returns a success response" do
+  describe 'GET #edit' do
+    it 'returns a success response' do
       gear = Gear.create! valid_attributes
-      get :edit, params: {id: gear.to_param}, session: valid_session
+      get :edit, params: { id: gear.to_param }, session: valid_session
       expect(response).to be_successful
     end
   end
 
-  describe "POST #create" do
-    context "with valid params" do
-      it "creates a new Gear" do
-        expect {
-          post :create, params: {gear: valid_attributes}, session: valid_session
-        }.to change(Gear, :count).by(1)
+  describe 'POST #create' do
+    subject(:post_create) do
+      post :create, params: { gear: attributes }, session: valid_session
+    end
+
+    context 'with valid params' do
+      let(:attributes) { valid_attributes }
+
+      it 'creates a new Gear' do
+        expect do
+          post_create
+        end.to change(Gear, :count).by(1)
       end
 
-      it "redirects to the created gear" do
-        post :create, params: {gear: valid_attributes}, session: valid_session
+      it 'redirects to the created gear' do
+        post_create
         expect(response).to redirect_to(Gear.last)
       end
     end
 
-    context "with invalid params" do
+    context 'with invalid params' do
+      let(:attributes) { invalid_attributes }
+
       it "returns a success response (i.e. to display the 'new' template)" do
-        post :create, params: { gear: invalid_attributes }, session: valid_session
+        post_create
         expect(response).to be_successful
       end
     end
   end
 
-  describe "PUT #update" do
-    context "with valid params" do
-      let(:new_attributes) {
+  describe 'PUT #update' do
+    subject(:put_update) do
+      put :update,
+          params: { id: gear.to_param, gear: new_attributes },
+          session: valid_session
+    end
+
+    let(:gear) { create :gear }
+
+    context 'with valid params' do
+      let(:new_attributes) do
         {
           name: 'Updated Gear'
         }
-      }
+      end
 
-      it "updates the requested gear" do
-        gear = Gear.create! valid_attributes
-        put :update, params: {id: gear.to_param, gear: new_attributes}, session: valid_session
+      it 'updates the requested gear' do
+        put_update
         gear.reload
         expect(gear.name).to eq 'Updated Gear'
       end
 
-      it "redirects to the gear" do
-        gear = Gear.create! valid_attributes
-        put :update, params: {id: gear.to_param, gear: valid_attributes}, session: valid_session
+      it 'redirects to the gear' do
+        put_update
         expect(response).to redirect_to(gear)
       end
     end
 
-    context "with invalid params" do
+    context 'with invalid params' do
+      let(:new_attributes) { invalid_attributes }
+
       it "returns a success response (i.e. to display the 'edit' template)" do
-        gear = Gear.create! valid_attributes
-        put :update, params: {id: gear.to_param, gear: invalid_attributes}, session: valid_session
+        put_update
         expect(response).to be_successful
       end
     end
   end
 
-  describe "DELETE #destroy" do
-    it "destroys the requested gear" do
-      gear = Gear.create! valid_attributes
-      expect {
-        delete :destroy, params: {id: gear.to_param}, session: valid_session
-      }.to change(Gear, :count).by(-1)
+  describe 'DELETE #destroy' do
+    subject(:delete_destroy) do
+      delete :destroy, params: { id: gear.to_param }, session: valid_session
     end
 
-    it "redirects to the gears list" do
-      gear = Gear.create! valid_attributes
-      delete :destroy, params: {id: gear.to_param}, session: valid_session
+    let!(:gear) { create :gear }
+
+    it 'destroys the requested gear' do
+      expect { delete_destroy }.to change(Gear, :count).by(-1)
+    end
+
+    it 'redirects to the gears list' do
+      delete_destroy
       expect(response).to redirect_to(gears_url)
     end
   end
-
 end

--- a/spec/controllers/hunters_controller_spec.rb
+++ b/spec/controllers/hunters_controller_spec.rb
@@ -40,61 +40,68 @@ RSpec.describe HuntersController, type: :controller do
   let(:user) { create :user }
 
   before do
-    @request.env['devise.mapping'] = Devise.mappings[:user]
     sign_in user
   end
 
   describe 'GET #index' do
-    subject { get :index, params: {}, session: valid_session }
+    subject(:get_index) { get :index, params: {}, session: valid_session }
 
-    context 'at least one hunter exists' do
+    context 'when at least one hunter exists' do
       let!(:hunter) { create :hunter }
 
       it 'returns a success response' do
-        subject
+        get_index
         expect(response).to be_successful
       end
     end
 
-    context 'no hunters exist' do
+    context 'without hunters' do
       it 'returns a success response' do
-        subject
+        get_index
         expect(response).to be_successful
       end
     end
   end
 
   describe 'GET #show' do
-    subject { get :show, params: { id: hunter.id }, session: valid_session }
+    subject(:get_show) do
+      get :show,
+          params: { id: hunter.id },
+          session: valid_session
+    end
 
     let(:hunter) { create :hunter }
 
     it 'returns a success response' do
-      subject
+      get_show
       expect(response).to be_successful
     end
   end
 
   describe 'GET #new' do
-    subject { get :new, params: {}, session: valid_session }
+    subject(:get_new) { get :new, params: {}, session: valid_session }
 
     it 'returns a success response' do
-      subject
+      get_new
       expect(response).to be_successful
     end
 
-    context 'banned user' do
+    context 'when user is banned' do
       let(:user) { create(:user, :banned) }
 
       it 'does not display new' do
-        subject
+        get_new
         expect(response).to redirect_to(new_user_session_path)
       end
     end
   end
 
   describe 'GET #edit' do
-    subject { get :edit, params: { id: hunter.to_param }, session: valid_session }
+    subject(:get_edit) do
+      get :edit,
+          params: { id: hunter.to_param },
+          session: valid_session
+    end
 
     let(:hunter) { create :hunter }
 
@@ -102,24 +109,28 @@ RSpec.describe HuntersController, type: :controller do
       let(:user) { create :user, :admin }
 
       it 'returns a success response' do
-        subject
+        get_edit
         expect(response).to be_successful
       end
     end
   end
 
   describe 'POST #create' do
-    subject { post :create, params: attributes, session: valid_session }
+    subject(:post_create) do
+      post :create,
+           params: attributes,
+           session: valid_session
+    end
 
     context 'with valid params' do
       let(:attributes) { valid_attributes }
 
       it 'creates a new Hunter' do
-        expect { subject }.to change(Hunter, :count).by(1)
+        expect { post_create }.to change(Hunter, :count).by(1)
       end
 
       it 'redirects to the created hunter' do
-        subject
+        post_create
         expect(response).to redirect_to(Hunter.last)
       end
     end
@@ -128,15 +139,17 @@ RSpec.describe HuntersController, type: :controller do
       let(:attributes) { invalid_attributes }
 
       it "returns a success response (i.e. to display the 'new' template)" do
-        subject
+        post_create
         expect(response).to be_successful
       end
     end
   end
 
   describe 'PUT #update' do
-    subject do
-      put :update, params: attributes.merge(id: hunter.to_param), session: valid_session
+    subject(:put_update) do
+      put :update,
+          params: attributes.merge(id: hunter.to_param),
+          session: valid_session
     end
 
     let!(:hunter) { create :hunter }
@@ -148,13 +161,13 @@ RSpec.describe HuntersController, type: :controller do
         let(:attributes) { valid_attributes }
 
         it 'updates the requested hunter' do
-          subject
+          put_update
           hunter.reload
           expect(hunter.name).to eq 'Ruudii'
         end
 
         it 'redirects to the hunter' do
-          subject
+          put_update
           expect(response).to redirect_to(hunter)
         end
       end
@@ -163,7 +176,7 @@ RSpec.describe HuntersController, type: :controller do
         let(:attributes) { invalid_attributes }
 
         it "returns a success response (i.e. to display the 'edit' template)" do
-          subject
+          put_update
           expect(response).to be_successful
         end
       end
@@ -171,24 +184,34 @@ RSpec.describe HuntersController, type: :controller do
   end
 
   describe 'DELETE #destroy' do
-    subject { delete :destroy, params: { id: hunter.to_param }, session: valid_session }
+    subject(:delete_destroy) do
+      delete :destroy, params: { id: hunter.to_param }, session: valid_session
+    end
 
     let!(:hunter) { create :hunter }
 
     it 'redirects user to sign in' do
-      subject
+      delete_destroy
       expect(response).to redirect_to(root_path)
+    end
+
+    context 'when user has created hunter' do
+      let!(:hunter) { create :hunter, user: user }
+
+      it 'destroys the requested hunter' do
+        expect { delete_destroy }.to change(Hunter, :count).by(-1)
+      end
     end
 
     context 'with admin user' do
       let(:user) { create :user, :admin }
 
       it 'destroys the requested hunter' do
-        expect { subject }.to change(Hunter, :count).by(-1)
+        expect { delete_destroy }.to change(Hunter, :count).by(-1)
       end
 
       it 'redirects to the hunters list' do
-        subject
+        delete_destroy
         expect(response).to redirect_to(hunters_url)
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,18 +3,21 @@
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort('The Rails environment is running in production mode!') if Rails.env.production?
+if Rails.env.production?
+  abort('The Rails environment is running in production mode!')
+end
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
-require 'devise'
 # Add coverage report to RSPEC
 require 'simplecov'
 SimpleCov.start
 require "pundit/rspec"
 
-# Add Factories
+# Add auth helpers + devise
+require 'support/devise'
+# Add factories
 require 'support/factory_bot'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -68,8 +71,4 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
-
-  config.include Devise::Test::IntegrationHelpers, type: :request
-  config.include Devise::Test::ControllerHelpers, type: :controller
-  config.include Warden::Test::Helpers
 end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# prep spec for devise
+require 'devise'
+
+module DeviseControllerSpecHelper
+  def sign_in(user)
+    @request.env['devise.mapping'] = Devise.mappings[:user]
+    super user
+  end
+end
+
+RSpec.configure do |config|
+  config.include DeviseControllerSpecHelper, type: :controller
+
+  config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Warden::Test::Helpers
+end


### PR DESCRIPTION
# Description
Our Controller specs were a bit of a mess. They no longer adhered to rubocop's style guide, there was a ton of repetition from devise, and the structure often didn't make use of factories.

# Changes
- Update RuboCop rules to make more sense with controller specs
- Move Devise to a spec/support/devise.rb file and move all RSpec configurations here
- Update controller specs to match the new standards