### PR TITLE
Allow Hunters to Retire

### DIFF
--- a/app/controllers/hunters_controller.rb
+++ b/app/controllers/hunters_controller.rb
@@ -104,12 +104,14 @@ class HuntersController < ApplicationController
   # @param sharp [Integer] the modifier for the Hunter's sharp rating
   # @param tough [Integer] the modifier for the Hunter's tough rating
   # @param weird [Integer] the modifier for the Hunter's weird rating
+  # @param rating_id [Integer] the id of the Rating object to attach
+  # @param retired [boolean] whether or not the hunter has retired
   # @!visibility public
   # @return [ActionController::Parameters]
   def hunter_params
     params.require(:hunter)
           .permit(:name, :playbook_id, :harm, :luck, :experience,
                   :charm, :cool, :sharp, :tough, :weird, :rating_id,
-                  gear_ids: [], move_ids: [])
+                  :retired, gear_ids: [], move_ids: [])
   end
 end

--- a/app/models/hunter.rb
+++ b/app/models/hunter.rb
@@ -54,12 +54,16 @@ class Hunter < ApplicationRecord
 
   # List all improvements that are available
   # based on the hunter's playbook, and excludes
-  # improvements the hunter has already taken
+  # improvements the hunter has already taken,
+  # and excludes advanced improvement if the
+  # hunter does not qualify
   #
   # @return [ActiveRecord::Collection]
   def available_improvements
     availables = playbook.improvements.where.not(id: improvements.select(:id))
-    availables = availables.not_advanced unless hunters_improvements.count >= 5
+    unless Improvement.advanced_eligible?(self)
+      availables = availables.not_advanced
+    end
     availables
   end
 

--- a/app/models/hunter.rb
+++ b/app/models/hunter.rb
@@ -14,6 +14,7 @@
 #  sharp       :integer
 #  tough       :integer
 #  weird       :integer
+#  retired     :boolean
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  playbook_id :bigint

--- a/app/models/improvement.rb
+++ b/app/models/improvement.rb
@@ -19,10 +19,14 @@
 # from when upgrading their character.
 class Improvement < ApplicationRecord
   OPTIONS_COUNT = 1
-  IMPROVEMENT_TYPES = %w[Improvement Improvements::RatingBoost
-                         Improvements::PlaybookMove Improvements::AnotherMove
-                         Improvements::ChangePlaybook Improvements::GainLuck
-                         Improvements::AdvancedMove].freeze
+  IMPROVEMENT_TYPES = %w[Improvement
+                         Improvements::AdvancedMove
+                         Improvements::AnotherMove
+                         Improvements::ChangePlaybook
+                         Improvements::GainLuck
+                         Improvements::PlaybookMove
+                         Improvements::RatingBoost
+                         Improvements::Retire].freeze
 
   belongs_to :playbook
 

--- a/app/models/improvements/retire.rb
+++ b/app/models/improvements/retire.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: improvements
+#
+#  id          :bigint           not null, primary key
+#  description :string
+#  type        :string
+#  rating      :integer
+#  stat_limit  :integer
+#  playbook_id :bigint
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  advanced    :boolean
+#
+module Improvements
+  # This improvement retires the hunter to safety
+  class Retire < Improvement
+    def apply(hunters_improvement)
+      return false if add_errors(hunters_improvement)
+
+      hunters_improvement.hunter.update!(retired: true)
+    end
+
+    def add_errors(hunters_improvement)
+      super(hunters_improvement)
+      if hunters_improvement.hunter.retired?
+        hunters_improvement.errors.add(:hunter, 'has already retired.')
+      end
+      hunters_improvement.errors.present?
+    end
+  end
+end

--- a/app/views/hunters/_form.html.erb
+++ b/app/views/hunters/_form.html.erb
@@ -71,6 +71,11 @@
         <%= form.number_field :weird, class: 'input' %>
       </div>
     </div>
+
+    <div class="field">
+      <%= form.label :retired %>
+      <%= form.check_box :retired %>
+    </div>
   </section>
 
   <div class="actions">

--- a/app/views/hunters/index.html.erb
+++ b/app/views/hunters/index.html.erb
@@ -7,12 +7,7 @@
       <th>Playbook</th>
       <th>Harm</th>
       <th>Luck</th>
-      <th>Experience</th>
-      <th>Charm</th>
-      <th>Cool</th>
-      <th>Sharp</th>
-      <th>Tough</th>
-      <th>Weird</th>
+      <th>Exp</th>
       <th colspan="2"></th>
     </tr>
   </thead>
@@ -22,14 +17,13 @@
       <tr>
         <td><%= link_to hunter.name, hunter %></td>
         <td><%= link_to_playbook(hunter) %></td>
-        <td><%= hunter.harm %></td>
-        <td><%= hunter.luck %></td>
-        <td><%= hunter.experience %></td>
-        <td><%= hunter.charm %></td>
-        <td><%= hunter.cool %></td>
-        <td><%= hunter.sharp %></td>
-        <td><%= hunter.tough %></td>
-        <td><%= hunter.weird %></td>
+        <% if hunter.retired? %>
+          <td colspan="3" class="has-text-centered">Retired</td>
+        <% else %>
+          <td class="has-text-centered"><%= hunter.harm %></td>
+          <td class="has-text-centered"><%= hunter.luck %></td>
+          <td class="has-text-centered"><%= hunter.experience %></td>
+        <% end %>
         <td>
           <% if policy(hunter).edit? %>
             <%= link_to 'Edit', edit_hunter_path(hunter) %>

--- a/app/views/hunters/show.html.erb
+++ b/app/views/hunters/show.html.erb
@@ -1,8 +1,16 @@
 <div class="columns">
   <div class="column">
-    <h1><%= @hunter.name %>, <%= link_to_playbook(@hunter) %></h1>
+    <h1>
+      <b><%= @hunter.retired? ? '(Retired)' : '' %></b>
+      <%= @hunter.name %>, 
+      <%= link_to_playbook(@hunter) %>
+    </h1>
     <p><i><%= @hunter.playbook.description %></i></p>
-    <hunter-ratings hunter_id=<%= "#{@hunter.id}" %>></hunter-ratings>
+    <% if @hunter.retired? %>
+      <%= display_rating @hunter %>
+    <% else %>
+      <hunter-ratings hunter_id=<%= "#{@hunter.id}" %>></hunter-ratings>
+    <% end %>
 
     <p>
       <strong>Harm:</strong>
@@ -35,6 +43,5 @@
     </p>
   </div>
 </div>
-<br />
 <%= link_to 'Edit', edit_hunter_path(@hunter), class: "button is-primary" %>
 <%= link_to 'Back', hunters_path, class: "button" %>

--- a/app/views/improvements/_form.html.erb
+++ b/app/views/improvements/_form.html.erb
@@ -10,7 +10,7 @@
   </div>
 
   <div class="field">
-     <%= form.label :advanced %>
+    <%= form.label :advanced %>
     <%= form.check_box :advanced %>
   </div>
 

--- a/app/views/moves/_moves.html.erb
+++ b/app/views/moves/_moves.html.erb
@@ -2,7 +2,7 @@
   <% moves.each do |move| %>
     <li><strong><%= link_to_move(move) %>:</strong> <%= move.description %>
       <div class="has-text-right">
-        <% if move.rollable? && hunter %>
+        <% if move.rollable? && hunter && !hunter.retired? %>
           <hunter-roll-move hunter_id=<%= hunter.id %> move_id=<%= move.id %> />
         <% end %>
       </div>

--- a/db/migrate/20200726135833_add_retired_to_hunters.rb
+++ b/db/migrate/20200726135833_add_retired_to_hunters.rb
@@ -1,0 +1,5 @@
+class AddRetiredToHunters < ActiveRecord::Migration[6.0]
+  def change
+    add_column :hunters, :retired, :bool
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_21_150901) do
+ActiveRecord::Schema.define(version: 2020_07_26_135833) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(version: 2020_06_21_150901) do
     t.datetime "updated_at", null: false
     t.bigint "playbook_id"
     t.bigint "user_id"
+    t.boolean "retired"
     t.index ["playbook_id"], name: "index_hunters_on_playbook_id"
     t.index ["user_id"], name: "index_hunters_on_user_id"
   end

--- a/db/seeds/playbooks/chosen.seeds.rb
+++ b/db/seeds/playbooks/chosen.seeds.rb
@@ -193,8 +193,9 @@ after :playbook do
       advanced: true
     },
     {
-      description: 'Retire this Hunter to safety.',
+      description: 'Retire this hunter to safety.',
       playbook: @chosen,
+      type: 'Improvements::Retire',
       advanced: true
     }
   ].each do |improvement|

--- a/db/seeds/playbooks/crooked.seeds.rb
+++ b/db/seeds/playbooks/crooked.seeds.rb
@@ -266,6 +266,11 @@ after :playbook do
       type: 'Improvements::GainLuck',
       description: 'Erase one used luck mark from your playbook.',
       advanced: true
+    },
+    {
+      type: 'Improvements::Retire',
+      description: 'Retire this hunter to safety.',
+      advanced: true
     }
   ].each do |improvement|
     Improvement.find_or_create_by!(playbook: @crooked, **improvement)

--- a/db/seeds/playbooks/divine.seeds.rb
+++ b/db/seeds/playbooks/divine.seeds.rb
@@ -164,6 +164,11 @@ after :playbook do
       type: 'Improvements::GainLuck',
       description: 'Erase one used luck mark from your playbook.',
       advanced: true
+    },
+    {
+      type: 'Improvements::Retire',
+      description: 'Retire this hunter to safety.',
+      advanced: true
     }
   ].each do |improvement|
     Improvement.find_or_create_by!(playbook: @divine, **improvement)

--- a/db/seeds/playbooks/professional.seeds.rb
+++ b/db/seeds/playbooks/professional.seeds.rb
@@ -199,8 +199,9 @@ after :playbook do
       advanced: true
     },
     {
-      description: 'Retire this Hunter to safety.',
+      description: 'Retire this hunter to safety.',
       playbook: @professional,
+      type: 'Improvements::Retire',
       advanced: true
     },
     {

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+namespace :data do
+  desc 'Update the type for all retired improvements'
+  task upgrade_retired_improvement: :environment do
+    Improvement
+      .where(description: 'Retire this Hunter to safety.')
+      .update_all(description: 'Retire this hunter to safety.', # rubocop:disable Rails/SkipsModelValidations
+                  type: 'Improvements::Retire')
+  end
+end

--- a/spec/factories/improvements.rb
+++ b/spec/factories/improvements.rb
@@ -19,6 +19,10 @@ FactoryBot.define do
     playbook
     description { 'Gain an Ally' }
     type { nil }
+
+    trait :advanced do
+      advanced { true }
+    end
   end
 
   factory :rating_boost, class: Improvements::RatingBoost do

--- a/spec/factories/improvements.rb
+++ b/spec/factories/improvements.rb
@@ -55,7 +55,13 @@ FactoryBot.define do
 
   factory :gain_luck, class: Improvements::GainLuck do
     playbook
-    description { 'Get back one used Luck point.'}
+    description { 'Get back one used Luck point.' }
     type { 'Improvements::GainLuck' }
+  end
+
+  factory :retire, class: Improvements::Retire do
+    playbook
+    description { 'Retire the hunter to safety.' }
+    type { 'Improvements::Retire' }
   end
 end

--- a/spec/models/hunter_spec.rb
+++ b/spec/models/hunter_spec.rb
@@ -51,15 +51,17 @@ RSpec.describe Hunter, type: :model do
 
       context 'hunter has no improvements' do
         it { is_expected.not_to include(advanced_improvement) }
+        it { is_expected.to include(improvement) }
       end
 
       context 'hunter has 5 improvements' do
-        let!(:hunters_improvements) do
-          create_list(:hunters_improvement,
+        let!(:improvements) do
+          create_list(:improvement,
                       5,
-                      hunter: hunter,
                       playbook: hunter.playbook)
         end
+
+        before { hunter.improvements << improvements }
 
         it { is_expected.to include(advanced_improvement) }
       end

--- a/spec/models/improvement_spec.rb
+++ b/spec/models/improvement_spec.rb
@@ -18,12 +18,72 @@ require 'rails_helper'
 
 RSpec.describe Improvement, type: :model do
   describe '.not_advanced' do
-    subject { Improvement.not_advanced }
+    subject { described_class.not_advanced }
 
     let!(:advanced_improvement) { create(:improvement, advanced: true) }
     let!(:improvement) { create(:improvement) }
 
     it { include(improvement) }
     it { is_expected.not_to include(advanced_improvement) }
+  end
+
+  describe '.advanced_eligible?' do
+    subject { described_class.advanced_eligible?(hunter) }
+
+    let(:hunter) { create :hunter }
+
+    it { is_expected.to be_falsey }
+
+    context 'with 5 improvements already' do
+      let!(:improvements) { create_list :improvement, 5, playbook: hunter.playbook }
+
+      before do
+        hunter.improvements << improvements
+        hunter.save
+      end
+
+      it { is_expected.to be_truthy }
+    end
+  end
+
+  describe '#add_errors' do
+    subject(:add_errors) do
+      improvement.add_errors(hunters_improvement)
+      hunters_improvement.errors.full_messages
+    end
+
+    let(:hunters_improvement) do
+      build :hunters_improvement,
+            hunter: hunter,
+            improvement: improvement
+    end
+    let(:hunter) { build :hunter }
+    let(:improvement) { build :improvement, playbook: hunter.playbook }
+
+    it { is_expected.to be_empty }
+
+    context 'when hunter playbook does not match improvement' do
+      let(:improvement) { build :improvement }
+
+      it 'raises mismatched playbook error' do
+        is_expected.to include match(/not match improvement playbook/)
+      end
+    end
+
+    context 'when the improvment is advanced' do
+      let(:improvement) { build :improvement, :advanced, playbook: hunter.playbook }
+
+      it 'complains the hunter is unqualified' do
+        is_expected.to include match(/qualified/)
+      end
+
+      context 'when hunter has advanced' do
+        let(:improvements) { create_list(:improvement, 5, playbook: hunter.playbook) }
+
+        before { hunter.improvements << improvements }
+
+        it { is_expected.to be_empty }
+      end
+    end
   end
 end

--- a/spec/models/improvements/retire_spec.rb
+++ b/spec/models/improvements/retire_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: improvements
+#
+#  id          :bigint           not null, primary key
+#  description :string
+#  type        :string
+#  rating      :integer
+#  stat_limit  :integer
+#  playbook_id :bigint
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  advanced    :boolean
+#
+require 'rails_helper'
+
+RSpec.describe Improvements::Retire, type: :model do
+  let(:retire) { create :retire, playbook: hunter.playbook }
+  let(:hunter) { create :hunter }
+  let(:hunters_improvement) do
+    build :hunters_improvement,
+          improvement: retire,
+          hunter: hunter,
+          improvable: ''
+  end
+
+  describe 'valid factory' do
+    it { expect(retire).to be_valid }
+  end
+
+  describe '#apply' do
+    subject(:apply) { retire.apply(hunters_improvement) }
+
+    it 'retired the hunter' do
+      expect { apply }.to change(hunter.reload, :retired).from(nil).to(true)
+    end
+
+    it 'does not invalidate the hunter' do
+      apply
+      expect(hunter).to be_valid
+    end
+  end
+
+  describe '#add_errors' do
+    subject(:add_errors) { retire.add_errors(hunters_improvement) }
+
+    it { is_expected.to be_falsey }
+
+    context 'when hunter has already retired' do
+      let(:hunter) { create :hunter, retired: true }
+
+      it 'adds errors to improvable' do
+        add_errors
+        error = 'Hunter has already retired.'
+        expect(hunters_improvement.errors.full_messages).to include error
+      end
+    end
+  end
+
+  describe '#improvable_options' do
+    subject { retire.improvable_options(hunter) }
+
+    it { is_expected.to eq [] }
+  end
+end


### PR DESCRIPTION
# Description
closes #101 

- Added Improvements::Retire to allow hunters to retire
- Added `retired` field to hunters to track if they are retired
- Updated Hunter UI to show that Hunter is retired
- Prevented Hunters from acquiring advanced improvements

# Deployment
- run `rake data:upgrade_retired_improvement` to update Improvments
   - You may need to delete the extra improvements from `db:seed`