### PR TITLE
Improve Experience for Logged out Users

### DIFF
--- a/app/controllers/hunters_controller.rb
+++ b/app/controllers/hunters_controller.rb
@@ -3,7 +3,7 @@
 # Restful Hunters Controller
 class HuntersController < ApplicationController
   before_action :set_hunter, only: %i[show edit update destroy]
-  before_action :authenticate_user!, only: %i[new create edit update destroy]
+  before_action :authenticate_user!
   # GET /hunters
   # GET /hunters.json
   # List all hunters

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -18,7 +18,7 @@ class ApplicationPolicy
   end
 
   def create?
-    @user.admin?
+    @user&.admin?
   end
 
   def new?
@@ -26,7 +26,7 @@ class ApplicationPolicy
   end
 
   def update?
-    @user.admin?
+    @user&.admin?
   end
 
   def edit?
@@ -34,7 +34,7 @@ class ApplicationPolicy
   end
 
   def destroy?
-    @user.admin?
+    @user&.admin?
   end
 
   # Default access scope for querying records.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  root 'hunters#index'
+  root 'playbooks#index'
   resources :gears
   devise_for :users
   resources :hunters do

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationPolicy, type: :policy do
+  subject { described_class }
+
+  let(:user) { build :user }
+  let(:admin) { build :user, :admin }
+  let(:logged_out_user) { nil }
+  let(:banned_user) { build :user, :banned }
+
+  permissions '.scope' do
+  end
+
+  let(:record) { build :playbook }
+
+  permissions :show? do
+    it { expect(subject).to permit(user, record) }
+    it { expect(subject).to permit(logged_out_user, record) }
+  end
+
+  permissions :create? do
+    it { expect(subject).to permit(admin, record) }
+    it { expect(subject).not_to permit(user, record) }
+    it { expect(subject).not_to permit(logged_out_user, record) }
+    it { expect(subject).not_to permit(banned_user, record) }
+  end
+
+  permissions :update? do
+    it { expect(subject).not_to permit(user, record) }
+    it { expect(subject).to permit(admin, record) }
+    it { expect(subject).not_to permit(logged_out_user, record) }
+  end
+
+  permissions :destroy? do
+    it { expect(subject).not_to permit(user, record) }
+    it { expect(subject).to permit(admin, record) }
+    it { expect(subject).not_to permit(logged_out_user, record) }
+  end
+end


### PR DESCRIPTION
# Description
Unauthenticated Users saw no records on the Hunters page, and the rule pages wouldn't load due to an error in ApplicationPolicy.
closes #158 

# Changes
* Add application policy spec
* Catch nil users in ApplicationPolicy
* Move the application root to Playbooks
* Require authorization on the Hunters Page