### PR TITLE
Refactor Improvable

### DIFF
--- a/app/controllers/hunters_improvements_controller.rb
+++ b/app/controllers/hunters_improvements_controller.rb
@@ -102,14 +102,7 @@ class HuntersImprovementsController < ApplicationController
 
   def update_improvable_option
     return if @hunters_improvement.improvable.blank?
-    raw = if Array.try_convert(@hunters_improvement.improvable)
-            @hunters_improvement.improvable.map do |option|
-              JSON.parse(option)
-            end
-          else
-            JSON.parse(@hunters_improvement.improvable)
-          end
-    @hunters_improvement.improvable = raw
+    @hunters_improvement.improvable = JSON.parse @hunters_improvement.improvable
   end
 
   # Never trust parameters from the scary internet,

--- a/app/javascript/components/hunters_improvement_form.vue
+++ b/app/javascript/components/hunters_improvement_form.vue
@@ -14,71 +14,49 @@
         >{{ improvement.description }}</option>
       </b-select>
     </b-field>
-    <b-field v-if="options.length > 0" label="Options" v-bind:message="optionDescription">
-      <b-dropdown v-model="selectedOptions" :multiple="multiple">
-        <button class="button is-primary" type="button" slot="trigger">
-          <span>{{ selectedDisplay }}</span>
-          <b-icon icon="menu-down"></b-icon>
-        </button>
-        <b-dropdown-item
-          v-for="option in options"
-          :value="stringifyValue(option)"
-          :key="optionKey(option)"
-        >{{ displayOption(option) }}</b-dropdown-item>
-      </b-dropdown>
+
+    <b-field
+      v-for="key in optionKeys"
+      :key="key"
+      :label="key"
+      v-bind:message="optionDescription(key)"
+      style="text-transform:capitalize"
+    >
+      <div>
+        <b-dropdown v-model="selectedOptions[key]" :multiple="multiple(key)">
+          <button class="button is-primary" type="button" slot="trigger">
+            <span>{{ selectedDisplay(key) }}</span>
+            <b-icon icon="menu-down"></b-icon>
+          </button>
+          <b-dropdown-item
+            v-for="option in options[key]['data']"
+            :value="option"
+            :key="optionKey(option)"
+          >{{ displayOption(option) }}</b-dropdown-item>
+        </b-dropdown>
+        <span class="control">
+          <input type="hidden" name="hunters_improvement[improvable]" :value="submittedOptions" />
+        </span>
+      </div>
     </b-field>
-    <span v-if="multiple">
-      <input
-        type="hidden"
-        v-for="option in selectedOptions"
-        name="hunters_improvement[improvable][]"
-        :value="option"
-      />
-    </span>
-    <span v-else>
-      <input type="hidden" name="hunters_improvement[improvable]" :value="selectedOptions" />
-    </span>
   </section>
 </template>
 
 <script>
 export default {
   computed: {
-    multiple: function() {
-      return this.optionsCount > 1;
+    optionKeys: function () {
+      return Object.keys(this.options);
     },
-    optionDescription: function() {
-      if (!this.selectedOptions) {
-        return "";
-      }
-      if (this.multiple && this.selectedOptions.length > 1) {
-        return "";
-      } else {
-        let option = JSON.parse(this.selectedOptions);
-        return option.description;
-      }
+    submittedOptions: function () {
+      return JSON.stringify(this.selectedOptions);
     },
-    selectedDisplay: function() {
-      if (!this.selectedOptions) {
-        return `Select {this.optionsCount}`;
-      }
-      if (this.multiple && this.selectedOptions.length > 1) {
-        this.selectedNames = this.selectedOptions.map(
-          option => JSON.parse(option).name
-        );
-        return this.selectedNames.join(", ");
-      } else {
-        let option = JSON.parse(this.selectedOptions);
-        return option.name ? option.name : option.improvable;
-      }
-    }
   },
-  data: function() {
+  data: function () {
     return {
       improvement: {},
-      selectedOptions: [],
-      options: [],
-      optionsCount: 0
+      selectedOptions: {},
+      options: {},
     };
   },
   methods: {
@@ -88,29 +66,41 @@ export default {
     optionKey(option) {
       return option.id ? option.id : option;
     },
+    optionDescription: function (key) {
+      if (!this.selectedOptions[key]) {
+        return "";
+      }
+      return this.selectedOptions[key].description || "";
+    },
+    multiple: function (key) {
+      if (this.options[key]) {
+        return this.options[key]["count"] > 1;
+      }
+    },
+    selectedDisplay: function (key) {
+      if (!this.selectedOptions[key]) {
+        return `Select ${this.options[key]["count"]}`;
+      }
+
+      if (this.multiple(key) && this.selectedOptions[key].length > 1) {
+        let selectedNames = this.selectedOptions[key].map(
+          (option) => option.name
+        );
+        return selectedNames.join(", ");
+      } else {
+        return this.selectedOptions[key].name || this.selectedOptions[key];
+      }
+    },
     selectImprovement(improvement) {
       fetch(
         `/improvements/${this.improvement}.json?hunter_id=${this.hunter_id}`
       )
-        .then(response => response.json())
-        .then(improvement => {
+        .then((response) => response.json())
+        .then((improvement) => {
           this.options = improvement["improvable_options"];
-          this.optionsCount = improvement["options_count"];
-          if (this.options) {
-            this.selectedOptions = [this.stringifyValue(this.options[0])];
-          }
         });
     },
-    stringifyValue(option) {
-      if (option) {
-        if (option.id) {
-          return JSON.stringify(option);
-        } else {
-          return JSON.stringify({ improvable: option });
-        }
-      }
-    }
   },
-  props: ["hunter_id", "improvements"]
+  props: ["hunter_id", "improvements"],
 };
 </script>

--- a/app/models/improvement.rb
+++ b/app/models/improvement.rb
@@ -18,7 +18,6 @@
 # These are the options the Hunter can choose
 # from when upgrading their character.
 class Improvement < ApplicationRecord
-  OPTIONS_COUNT = 1
   IMPROVEMENT_TYPES = %w[Improvement
                          Improvements::AdvancedMove
                          Improvements::AnotherMove
@@ -69,10 +68,6 @@ class Improvement < ApplicationRecord
   end
 
   def improvable_options(_hunter)
-    []
-  end
-
-  def options_count
-    Improvement::OPTIONS_COUNT
+    {}
   end
 end

--- a/app/models/improvements/advanced_move.rb
+++ b/app/models/improvements/advanced_move.rb
@@ -17,8 +17,6 @@
 module Improvements
   # This is for Improvements like "Mark two of the basic moves as advanced"
   class AdvancedMove < Improvement
-    OPTIONS_COUNT = 2
-
     def apply(hunters_improvement)
       return false if add_errors(hunters_improvement)
       hunters_moves(hunters_improvement).update_all(advanced: true)
@@ -68,19 +66,16 @@ module Improvements
     end
 
     def move_ids(hunters_improvement)
-      hunters_improvement.improvable.pluck('id')
+      hunters_improvement.improvable.dig('moves').pluck('id')
     end
 
     def improvable_options(hunter)
-      Moves::Basic
-        .joins("LEFT JOIN hunters_moves ON moves.id = hunters_moves.move_id \
-                  AND hunter_id = #{hunter.id}")
-        .where(hunters_moves: { advanced: [false, nil] })
-        .select(:'moves.id', :name, :description)
-    end
-
-    def options_count
-      Improvements::AdvancedMove::OPTIONS_COUNT
+      moves = Moves::Basic
+              .joins("LEFT JOIN hunters_moves ON \
+                moves.id = hunters_moves.move_id AND hunter_id = #{hunter.id}")
+              .where(hunters_moves: { advanced: [false, nil] })
+              .select(:'moves.id', :name, :description)
+      { moves: { data: moves, count: 2 } }
     end
   end
 end

--- a/app/models/improvements/another_move.rb
+++ b/app/models/improvements/another_move.rb
@@ -41,7 +41,7 @@ module Improvements
     end
 
     def move(hunters_improvement)
-      Move.find(hunters_improvement.improvable&.dig('id'))
+      Move.find(hunters_improvement.improvable&.dig('move', 'id'))
     rescue ActiveRecord::RecordNotFound => e
       hunters_improvement.errors.add(:improvable, e.message)
       false
@@ -56,9 +56,10 @@ module Improvements
     end
 
     def improvable_options(hunter)
-      Move.where.not(id: hunter.moves.select(:id))
-          .where.not(playbook_id: playbook_id)
-          .select(:id, :name, :description)
+      moves = Move.where.not(id: hunter.moves.select(:id))
+                  .where.not(playbook_id: playbook_id)
+                  .select(:id, :name, :description)
+      { move: { data: moves, count: 1 } }
     end
   end
 end

--- a/app/models/improvements/change_playbook.rb
+++ b/app/models/improvements/change_playbook.rb
@@ -39,14 +39,15 @@ module Improvements
       playbook.class <= Playbook
     end
 
-    def improvable_options(_hunter)
-      Playbook.where.not(id: playbook_id).select(:id, :name, :description)
-    end
-
     def new_playbook(hunters_improvement)
-      Playbook.find(hunters_improvement.improvable&.dig('id'))
+      Playbook.find(hunters_improvement.improvable&.dig('playbook', 'id'))
     rescue ActiveRecord::RecordNotFound => e
       hunters_improvement.errors.add(:improvable, e.message)
+    end
+
+    def improvable_options(_hunter)
+      playbooks = Playbook.where.not(id: playbook_id).select(:id, :name, :description)
+      { playbook: { data: playbooks, count: 1 } }
     end
   end
 end

--- a/app/models/improvements/change_playbook.rb
+++ b/app/models/improvements/change_playbook.rb
@@ -46,7 +46,8 @@ module Improvements
     end
 
     def improvable_options(_hunter)
-      playbooks = Playbook.where.not(id: playbook_id).select(:id, :name, :description)
+      playbooks = Playbook.where.not(id: playbook_id)
+                          .select(:id, :name, :description)
       { playbook: { data: playbooks, count: 1 } }
     end
   end

--- a/app/models/improvements/playbook_move.rb
+++ b/app/models/improvements/playbook_move.rb
@@ -49,17 +49,18 @@ module Improvements
     end
 
     def move(hunters_improvement)
-      Move.find(hunters_improvement.improvable&.dig('id'))
+      Move.find(hunters_improvement.improvable&.dig('move', 'id'))
     rescue ActiveRecord::RecordNotFound => e
       hunters_improvement.errors.add(:improvable, e.message)
       false
     end
 
     def improvable_options(hunter)
-      Move
-        .where.not(id: hunter.moves.select(:id))
-        .where(playbook_id: playbook_id)
-        .select(:id, :name, :description)
+      moves = Move
+              .where.not(id: hunter.moves.select(:id))
+              .where(playbook_id: playbook_id)
+              .select(:id, :name, :description)
+      { move: { data: moves, count: 1 } }
     end
   end
 end

--- a/app/models/improvements/rating_boost.rb
+++ b/app/models/improvements/rating_boost.rb
@@ -17,6 +17,8 @@
 module Improvements
   # This is for Improvements like "Get +1 Weird, max +3"
   class RatingBoost < Improvement
+    RATINGS_SELECT = { rating: { data: Rating::LIST, count: 1 } }.freeze
+
     def apply(hunters_improvement)
       return false if add_errors(hunters_improvement)
       configured_rating = configured_rating(hunters_improvement)
@@ -38,12 +40,12 @@ module Improvements
       hunters_improvement.errors.present?
     end
 
-    def improvable_options(_hunter)
-      rating ? [] : Rating::LIST
+    def configured_rating(hunters_improvement)
+      rating || hunters_improvement.improvable&.dig('rating')
     end
 
-    def configured_rating(hunters_improvement)
-      rating || hunters_improvement.improvable&.dig('improvable')
+    def improvable_options(_hunter)
+      rating ? {} : RATINGS_SELECT
     end
   end
 end

--- a/app/views/improvements/show.json.jbuilder
+++ b/app/views/improvements/show.json.jbuilder
@@ -2,4 +2,3 @@
 
 json.partial! 'improvements/improvement', improvement: @improvement
 json.improvable_options @improvable_options if @improvable_options
-json.options_count @improvement.options_count

--- a/spec/controllers/hunters_improvements_controller_spec.rb
+++ b/spec/controllers/hunters_improvements_controller_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe HuntersImprovementsController, type: :controller do
           {
             hunter_id: hunter.id,
             improvement_id: valid_improvement.id,
-            improvable: '{"id":25,"name":"Ancient Arts","description":"desc"}'
+            improvable: '{"move":{"id":25,"name":"Ancient Arts","description":"desc"}}'
           }
         end
         let(:format_type) { :html }
@@ -134,7 +134,7 @@ RSpec.describe HuntersImprovementsController, type: :controller do
 
         it 'has a well-formatted json improvable' do
           post_create
-          expect(HuntersImprovement.last.improvable['id']).to eq 25
+          expect(HuntersImprovement.last.improvable.dig("move", "id")).to eq 25
         end
       end
 
@@ -142,7 +142,7 @@ RSpec.describe HuntersImprovementsController, type: :controller do
         let(:attributes) do
           {
             hunter_id: hunter.id, improvement_id: valid_improvement.id,
-            improvable: ['{"id":25,"name":"Ancient Arts","description":"desc"}']
+            improvable: '{"move":[{"id":25,"name":"Ancient Arts","description":"desc"}]}'
           }
         end
         let(:format_type) { :html }
@@ -153,7 +153,7 @@ RSpec.describe HuntersImprovementsController, type: :controller do
 
         it 'has a well-formatted json improvable' do
           post_create
-          expect(HuntersImprovement.last.improvable[0]['id']).to eq 25
+          expect(HuntersImprovement.last.improvable.dig("move", 0, "id")).to eq 25
         end
       end
     end

--- a/spec/controllers/improvements_controller_spec.rb
+++ b/spec/controllers/improvements_controller_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe ImprovementsController, type: :controller do
           it 'includes improvable options' do
             get_show
             resp = JSON.parse(response.body)
-            expect(resp['improvable_options'].first['id']).to eq move.id
+            expect(resp['improvable_options'].dig('move', 'data', 0, 'id')).to eq move.id
           end
         end
       end

--- a/spec/models/improvements/advanced_move_spec.rb
+++ b/spec/models/improvements/advanced_move_spec.rb
@@ -16,7 +16,7 @@
 #
 require 'rails_helper'
 
-RSpec.describe Improvements::AnotherMove, type: :model do
+RSpec.describe Improvements::AdvancedMove, type: :model do
   let(:advanced_move) { create(:advanced_move) }
   let(:hunters_improvement) do
     build :hunters_improvement,
@@ -24,7 +24,14 @@ RSpec.describe Improvements::AnotherMove, type: :model do
           improvement: advanced_move,
           improvable: improvable
   end
-  let(:improvable) { [{ 'id': move.id, 'name': move.name, 'description': move.description }, { 'id': move2.id, 'name': move2.name, 'description': move2.description }] }
+  let(:improvable) do
+    {
+      moves: [
+        { 'id': move.id, 'name': move.name, 'description': move.description },
+        { 'id': move2.id, 'name': move2.name, 'description': move2.description }
+      ]
+    }
+  end
   let(:hunter) { create :hunter, playbook: advanced_move.playbook }
   let(:move) { create :moves_basic }
   let(:move2) { create :moves_basic }
@@ -40,8 +47,13 @@ RSpec.describe Improvements::AnotherMove, type: :model do
 
     it { is_expected.to be_truthy }
 
-    context 'one move' do
-      let(:improvable) { [{ 'id': move.id, 'name': move.name, 'description': move.description }] }
+    context 'with only one move' do
+      let(:improvable) do
+        {
+          moves:
+          [{ 'id': move.id, 'name': move.name, 'description': move.description }]
+        }
+      end
 
       it { is_expected.to be_falsey }
 
@@ -86,7 +98,7 @@ RSpec.describe Improvements::AnotherMove, type: :model do
   end
 
   describe '#improvable_options' do
-    subject { advanced_move.improvable_options(hunter) }
+    subject { advanced_move.improvable_options(hunter).dig(:moves, :data) }
 
     it { is_expected.to include(move) }
     it { is_expected.to include(move2) }
@@ -110,11 +122,5 @@ RSpec.describe Improvements::AnotherMove, type: :model do
         expect(subject.count(1)).to eq Moves::Basic.count
       end
     end
-  end
-
-  describe '#options_count' do
-    subject { advanced_move.options_count }
-
-    it { is_expected.to eq 2 }
   end
 end

--- a/spec/models/improvements/another_move_spec.rb
+++ b/spec/models/improvements/another_move_spec.rb
@@ -18,13 +18,16 @@ require 'rails_helper'
 
 RSpec.describe Improvements::AnotherMove, type: :model do
   let(:another_move) { create(:another_move) }
-  let(:hunters_improvement) {
+  let(:hunters_improvement) do
     build :hunters_improvement,
           hunter: hunter,
           improvement: another_move,
-          improvable: {'id': move.id, 'name': move.name, 'description': move.description }
-  }
-  let(:hunter) { create :hunter, playbook: another_move.playbook  }
+          improvable: { 'move':
+            { 'id': move.id,
+              'name': move.name,
+              'description': move.description } }
+  end
+  let(:hunter) { create :hunter, playbook: another_move.playbook }
   let(:move) { create :moves_rollable, playbook: create(:playbook) }
 
   describe '#apply' do
@@ -99,7 +102,12 @@ RSpec.describe Improvements::AnotherMove, type: :model do
     subject { another_move.move(hunters_improvement) }
 
     let(:move) { create :move }
-    let(:hunters_improvement) { build :hunters_improvement, improvement: another_move, hunter: hunter, improvable: { "id": move.id, "name": move.name, "description": move.description } }
+    let(:hunters_improvement) do
+      build :hunters_improvement,
+            improvement: another_move,
+            hunter: hunter,
+            improvable: { 'move': { "id": move.id, "name": move.name, "description": move.description } }
+    end
 
     it { is_expected.to eq Move.find move.id }
   end
@@ -116,6 +124,7 @@ RSpec.describe Improvements::AnotherMove, type: :model do
 
     context 'improvable is not a move' do
       let(:move) { create(:playbook) }
+
       it 'adds errors to the hunters improvement' do
         subject
         expect(hunters_improvement.errors.full_messages).to include "Improvable Couldn't find Move with 'id'=#{move.id}"

--- a/spec/models/improvements/change_playbook_spec.rb
+++ b/spec/models/improvements/change_playbook_spec.rb
@@ -22,21 +22,22 @@ RSpec.describe Improvements::ChangePlaybook, type: :model do
     build :hunters_improvement,
           improvement: change_playbook,
           hunter: hunter,
-          improvable: {"id": playbook.id }
+          improvable: { "id": playbook.id }
   end
 
   describe '#apply' do
     subject { change_playbook.apply(hunters_improvement) }
+
     let(:hunters_improvement) do
       build :hunters_improvement,
-             improvement: change_playbook,
-             hunter: hunter,
-             improvable: {"id": playbook.id }
-           end
+            improvement: change_playbook,
+            hunter: hunter,
+            improvable: { playbook: { "id": playbook.id } }
+    end
     let(:hunter) { create :hunter, playbook: change_playbook.playbook }
     let(:playbook) { create :playbook }
 
-    it 'should give the hunter a new playbook' do
+    it 'gives the hunter a new playbook' do
       expect { subject }.to change(hunter.reload, :playbook).from(hunter.playbook).to(playbook)
     end
 
@@ -48,6 +49,7 @@ RSpec.describe Improvements::ChangePlaybook, type: :model do
 
   describe '#add_errors' do
     subject { change_playbook.add_errors(hunters_improvement) }
+
     let(:hunter) { create :hunter, playbook: change_playbook.playbook }
 
     context 'with valid playbook' do
@@ -84,7 +86,7 @@ RSpec.describe Improvements::ChangePlaybook, type: :model do
   end
 
   describe '#improvable_options' do
-    subject { change_playbook.improvable_options(hunter) }
+    subject { change_playbook.improvable_options(hunter).dig(:playbook, :data) }
 
     let(:hunter) { create :hunter, playbook: change_playbook.playbook }
     let!(:playbook) { create :playbook }

--- a/spec/models/improvements/playbook_move_spec.rb
+++ b/spec/models/improvements/playbook_move_spec.rb
@@ -18,8 +18,10 @@ require 'rails_helper'
 
 RSpec.describe Improvements::PlaybookMove, type: :model do
   let(:playbook_move) { create(:playbook_move) }
-  let(:hunters_improvement) { build :hunters_improvement, improvement: playbook_move, hunter: hunter, improvable: { "id": move.id } }
-  let(:hunter) { create :hunter, playbook: playbook_move.playbook  }
+  let(:hunters_improvement) do
+    build :hunters_improvement, improvement: playbook_move, hunter: hunter, improvable: { 'move': { "id": move.id } }
+  end
+  let(:hunter) { create :hunter, playbook: playbook_move.playbook }
   let(:move) { create :moves_rollable, playbook: playbook_move.playbook }
 
   describe '#apply' do
@@ -102,6 +104,7 @@ RSpec.describe Improvements::PlaybookMove, type: :model do
 
     context 'improvable is not a move' do
       let(:move) { create(:playbook) }
+
       it 'adds errors to the hunters improvement' do
         subject
         expect(hunters_improvement.errors.full_messages).to include "Improvable Couldn't find Move with 'id'=#{move.id}"

--- a/spec/models/improvements/rating_boost_spec.rb
+++ b/spec/models/improvements/rating_boost_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Improvements::RatingBoost, type: :model do
 
       context 'configured rating boost' do
         let(:rating_boost) { create :rating_boost, rating: nil }
-        let(:hunters_improvement) { build(:hunters_improvement, hunter: hunter, improvement: rating_boost, improvable: { improvable: 'cool' }) }
+        let(:hunters_improvement) { build(:hunters_improvement, hunter: hunter, improvement: rating_boost, improvable: { rating: 'cool' }) }
 
         it { expect { subject }.to change(hunter, :cool).by(1) }
         it "sets the hunter's cool to 1" do
@@ -65,38 +65,16 @@ RSpec.describe Improvements::RatingBoost, type: :model do
       hunter.save
     end
 
-    let(:hunter) { create(:hunter,  playbook: rating_boost.playbook, charm: 2) }
+    let(:hunter) { create(:hunter, playbook: rating_boost.playbook, charm: 2) }
 
     it { expect { subject }.to change(hunter.reload, :charm).by(1) }
-  end
-
-  describe '#add_errors' do
-    subject { rating_boost.add_errors(hunters_improvement) }
-    let(:hunters_improvement) { build(:hunters_improvement, hunter: hunter, improvement: rating_boost) }
-
-    context 'invalid hunter' do
-      let(:hunter) { create :hunter, charm: 3 }
-
-      it 'applies errors to hunters improvement' do
-        subject
-        expect(hunters_improvement.errors.full_messages).to include "Hunter charm rating would exceed max for improvement."
-      end
-    end
-
-    context 'valid hunter' do
-      let(:hunter) { create :hunter,  playbook: rating_boost.playbook, charm: 2 }
-
-      it 'leaves the hunter improvement error free' do
-        subject
-        expect(hunters_improvement.errors).to be_empty
-      end
-    end
   end
 
   describe '#configured_rating' do
     subject { rating_boost.configured_rating(hunters_improvement) }
 
     let(:hunter) { create :hunter, playbook: rating_boost.playbook }
+    let(:hunters_improvement) { build(:hunters_improvement, hunter: hunter, improvement: rating_boost) }
 
     context 'rating configured on improvement' do
       it { is_expected.to eq 'charm' }
@@ -104,7 +82,7 @@ RSpec.describe Improvements::RatingBoost, type: :model do
 
     context 'rating configured on hunters improvement' do
       let(:rating_boost) { create :rating_boost, rating: nil }
-      let(:hunters_improvement) { create(:hunters_improvement, hunter: hunter, improvement: rating_boost, improvable: { improvable: 'cool' }) }
+      let(:hunters_improvement) { create(:hunters_improvement, hunter: hunter, improvement: rating_boost, improvable: { rating: 'cool' }) }
 
       it { is_expected.to eq 'cool' }
     end

--- a/spec/models/improvements/retire_spec.rb
+++ b/spec/models/improvements/retire_spec.rb
@@ -62,6 +62,6 @@ RSpec.describe Improvements::Retire, type: :model do
   describe '#improvable_options' do
     subject { retire.improvable_options(hunter) }
 
-    it { is_expected.to eq [] }
+    it { is_expected.to be_empty }
   end
 end


### PR DESCRIPTION
Improvable on the HuntersImprovament stores info like what move to give the hunter, what playbook to give the hunter, and what haven to give a move to. This PR refactors improbable, so multiple options can be supplied, and the type is defined in the object.