### PR TITLE
112: Seedfile for The Wronged

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ To run your tests:\
 To run rubocop:\
 `docker exec -it hunterskeepers_web_1 bundle exec rubocop`
 
-To reset the database with the seed data:\
+To reset the database with the seed data:
 1. (If server was running) Shut down the web server: `docker-compose stop web`
 2. Reset the DB: `docker-compose run web bundle exec rake db:reset`
 3. (If server was running) Bring the web server back up: `docker-compose start web`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,11 @@ To run your tests:\
 To run rubocop:\
 `docker exec -it hunterskeepers_web_1 bundle exec rubocop`
 
+To reset the database with the seed data:\
+1. (If server was running) Shut down the web server: `docker-compose stop web`
+2. Reset the DB: `docker-compose run web bundle exec rake db:reset`
+3. (If server was running) Bring the web server back up: `docker-compose start web`
+
 ### Updating Node Modules
 You'll have to update your node_modules folder if you see a message similar to the one below.
 ```

--- a/db/seeds/playbooks/chosen.seeds.rb
+++ b/db/seeds/playbooks/chosen.seeds.rb
@@ -22,7 +22,7 @@ after :playbook do
   your immediate future.'
   },
    {
-     name: 'I’m Here For A Reason',
+     name: "I'm Here For A Reason",
      type: 'Moves::Descriptive',
      playbook_id: @chosen.id,
      description: 'There’s something you are
@@ -118,14 +118,14 @@ after :playbook do
       description: 'Get +1 Weird, max +3',
       type: 'Improvements::RatingBoost',
       stat_limit: 3,
-      rating: :tough,
+      rating: :weird,
       playbook: @chosen
     },
     {
       description: 'Get +1 Tough, max +3',
       type: 'Improvements::RatingBoost',
       stat_limit: 3,
-      rating: :weird,
+      rating: :tough,
       playbook: @chosen
     },
     {
@@ -138,6 +138,7 @@ after :playbook do
       description: 'Take another Chosen move',
       type: 'Improvements::PlaybookMove',
       playbook: @chosen,
+      # Used to differentiate (and initially hide this) from the identical improvement above.
       stat_limit: -1
     },
     {
@@ -150,6 +151,7 @@ after :playbook do
       description: 'Take a move from another playbook',
       type: 'Improvements::AnotherMove',
       playbook: @chosen,
+      # Used to differentiate (and initially hide this) from the identical improvement above.
       stat_limit: -1
     },
     {
@@ -176,7 +178,7 @@ after :playbook do
       advanced: true
     },
     {
-      description: 'Create a second  hunter to play as well as this one.',
+      description: 'Create a second hunter to play as well as this one.',
       playbook: @chosen,
       advanced: true
     },

--- a/db/seeds/playbooks/wronged.seeds.rb
+++ b/db/seeds/playbooks/wronged.seeds.rb
@@ -1,0 +1,299 @@
+# frozen_string_literal: true
+
+after :playbook do
+  @wronged = Playbook.find_by! name: 'The Wronged'
+
+  ######
+  # Moves
+  # ratings: charm: 0, cool: 1, sharp: 2, tough: 3, weird: 4
+  ######
+  [{
+    name: "I Know My Prey",
+    type: 'Moves::Descriptive',
+    playbook_id: @wronged.id,
+    description: 'You get +1 ongoing when knowingly investigating, pursuing or fighting the breed of
+monster that caused your loss.'
+  },
+   {
+     name: 'Berserk',
+     type: 'Moves::Descriptive',
+     playbook_id: @wronged.id,
+     description: 'No matter how much harm you take, you
+can always keep going until the current fight is over.
+During a fight, the Keeper may not use harm moves
+on you and you cannot die. When the fight ends, all
+harm takes effect as normal'
+   },
+   {
+     name: 'NEVER AGAIN',
+     type: 'Moves::Descriptive',
+     playbook_id: @wronged.id,
+     description: 'In combat, you may choose to
+*protect someone* without rolling, as if you had
+rolled a 10+, but you may not choose to "suffer little
+harm."'
+   },
+   {
+     name: 'What Does Not Kill Me...',
+     type: 'Moves::Descriptive',
+     playbook_id: @wronged.id,
+     description: ' If you have suffered harm
+in a fight, you gain +1 ongoing until the fight is over.'
+   },
+   {
+     name: 'Fervor',
+     type: 'Moves::Descriptive',
+     playbook_id: @wronged.id,
+     description: 'When you *manipulate someone*, roll
++Tough instead of +Charm.'
+   },
+   {
+     name: 'Safety First',
+     type: 'Moves::Descriptive',
+     playbook_id: @wronged.id,
+     description: 'You have jury-rigged extra protection
+into your gear, giving you +1 armour (maximum
+2-armour).'
+   },
+   {
+     name: 'DIY Surgery',
+     rating: :cool,
+     ten_plus: 'On a 10+ it’s all good, it counts as normal first aid,
+plus stabilize the injury and heal 1 harm.',
+     seven_to_nine: 'On a 7-9
+it counts as normal first aid, plus one of these, your
+choice:
+• Stabilise the injury but the patient takes -1
+forward.
+• Heal 1-harm and stabilise for now, but it will
+return as 2-harm and become unstable again
+later.
+• Heal 1-harm and stabilise but the patient takes
+-1 ongoing until it’s fixed properly',
+     type: 'Moves::Rollable',
+     playbook_id: @wronged.id,
+     description: 'When you do quick and dirty first
+aid on someone (including yourself), roll +Cool.'
+   },
+   {
+       name: 'Tools Matter',
+       type: 'Moves::Descriptive',
+       playbook_id: @wronged.id,
+       description: 'With your signature weapon (see
+your gear, below), you get +1 to *kick some ass*.'
+   }].each do |move|
+    Move.find_or_create_by!(move)
+  end
+
+  #####
+  # Gear
+  #####
+
+  # Note: Signature weapon could also be:
+  # Specialist weapons for destroying your foes (e.g.
+  # wooden stakes and mallet for vampires, silver dagger
+  # for werewolves, etc.).
+  # 4-harm against the specific
+  # creatures it targets, 1-harm otherwise, and other
+  # tags by agreement with the Keeper
+
+  [
+    {
+      name: 'Sawn-off shotgun',
+      harm: 3,
+      tag_list: %w[hand/close messy loud reload]
+    },
+    {
+      name: 'Hand cannon',
+      harm: 3,
+      tag_list: %w[close loud]
+    },
+    {
+      name: 'Fighting knife',
+      harm: 2,
+      tag_list: %w[hand quiet]
+    },
+    {
+      name: 'Huge sword or huge axe',
+      harm: 3,
+      tag_list: %w[harm hand messy heavy],
+    },
+    {
+      name: 'Enchanted dagger',
+      harm: 2,
+      tag_list: %w[harm hand magic]
+    },
+    {
+      name: 'Chainsaw',
+      harm: 2,
+      tag_list: %w[hand messy unreliable loud heavy]
+    },
+    {
+      name: '.38 resolver',
+      harm: 2,
+      tag_list: %w[close reload loud]
+    },
+    {
+      name: '9mm',
+      harm: 2,
+      tag_list: %w[close loud]
+    },
+    {
+      name: 'Hunting rifle',
+      harm: 2,
+      tag_list: %w[far loud]
+    },
+    {
+      name: 'Shotgun',
+      harm: 3,
+      tag_list: %w[close messy loud]
+    },
+    {
+      name: 'Big knife',
+      harm: 1,
+      tag_list: %w[hand]
+    },
+    {
+      name: 'Brass knuckles',
+      harm: 1,
+      tag_list: %w[close hand stealthy]
+    },
+    {
+      name: 'Assault rifle',
+      harm: 3,
+      tag_list: %w[close area loud reload]
+    },
+  ].each do |gear_attrs|
+    gear = Gear.find_or_create_by!(
+        name: gear_attrs[:name],
+        playbook: @wronged
+    )
+    gear.update!(gear_attrs)
+  end
+
+  #####
+  # Improvements
+  #####
+  [
+    {
+      description: 'Get +1 Tough, max +3',
+      type: 'Improvements::RatingBoost',
+      stat_limit: 3,
+      rating: :tough,
+      playbook: @wronged
+    },
+    {
+      description: 'Get +1 Cool, max +2',
+      type: 'Improvements::RatingBoost',
+      stat_limit: 2,
+      rating: :cool,
+      playbook: @wronged
+    },
+    {
+      description: 'Get +1 Sharp, max +2',
+      type: 'Improvements::RatingBoost',
+      stat_limit: 2,
+      rating: :sharp,
+      playbook: @wronged
+    },
+    {
+      description: 'Get +1 Weird, max +2',
+      type: 'Improvements::RatingBoost',
+      stat_limit: 2,
+      rating: :weird,
+      playbook: @wronged
+    },
+    {
+      description: 'Take another Wronged move',
+      type: 'Improvements::AnotherMove',
+      playbook: @wronged,
+      stat_limit: 0
+    },
+    {
+      description: 'Take another Wronged move',
+      type: 'Improvements::AnotherMove',
+      playbook: @wronged,
+      # Used to differentiate (and initially hide this) from the identical improvement above.
+      stat_limit: -1
+    },
+    {
+      description: 'Gain a haven, like the Expert has, with two options',
+      playbook: @wronged
+    },
+    {
+      description: 'Add one more option to your haven',
+      type: 'Improvements::HavenMove',
+      playbook: @wronged
+    },
+    {
+      description: 'Take a move from another playbook',
+      type: 'Improvements::AnotherMove',
+      playbook: @wronged,
+      stat_limit: 0
+    },
+    {
+      description: 'Take a move from another playbook',
+      type: 'Improvements::AnotherMove',
+      playbook: @wronged,
+      # Used to differentiate (and initially hide this) from the identical improvement above.
+      stat_limit: -1
+    },
+    {
+      description: 'Get +1 to any rating, max +3.',
+      playbook: @wronged,
+      type: 'Improvements::RatingBoost',
+      stat_limit: 3,
+      advanced: true
+    },
+    {
+      description: 'Change this hunter to a new type.',
+      playbook: @wronged,
+      type: 'Improvements::ChangePlaybook',
+      advanced: true
+    },
+    {
+      description: 'Create a second hunter to play as well as this one.',
+      playbook: @wronged,
+      advanced: true
+    },
+    {
+      description: 'Mark two of the basic moves as advanced.',
+      playbook: @wronged,
+      type: 'Improvements::AdvancedMove',
+      advanced: true
+    },
+    {
+      description: 'Mark another two of the basic moves as advanced',
+      playbook: @wronged,
+      type: 'Improvements::AdvancedMove',
+      advanced: true
+    },
+    {
+      description: 'Retire this hunter to safety.',
+      playbook: @wronged,
+      type: 'Improvements::Retire',
+      advanced: true
+    },
+    {
+      description: 'You track down the specific monster(s) responsible for your loss. The Keeper must make the next
+mystery about them',
+      playbook: @wronged,
+      advanced: true
+    },
+    {
+      description: 'Change the target of your vengeful rage. Pick a new
+monster breed: I know my prey now applies to them
+instead.',
+      playbook: @wronged,
+      advanced: true
+    },
+    {
+      description: 'Get back one used Luck point.',
+      playbook: @wronged,
+      type: 'Improvements::GainLuck',
+      advanced: true
+    },
+  ].each do |improvement|
+    Improvement.find_or_create_by!(improvement)
+  end
+end

--- a/db/seeds/playbooks/wronged.seeds.rb
+++ b/db/seeds/playbooks/wronged.seeds.rb
@@ -70,10 +70,11 @@ return as 2-harm and become unstable again
 later.
 • Heal 1-harm and stabilise but the patient takes
 -1 ongoing until it’s fixed properly',
+     six_and_under: 'No heroic measures undertaken; no impact on the efficacy of your first aid',
      type: 'Moves::Rollable',
      playbook_id: @wronged.id,
-     description: 'When you do quick and dirty first
-aid on someone (including yourself), roll +Cool.'
+     description: 'When you do *quick and dirty first
+aid on someone* (including yourself), roll +Cool.'
    },
    {
        name: 'Tools Matter',
@@ -205,13 +206,13 @@ your gear, below), you get +1 to *kick some ass*.'
     },
     {
       description: 'Take another Wronged move',
-      type: 'Improvements::AnotherMove',
+      type: 'Improvements::PlaybookMove',
       playbook: @wronged,
       stat_limit: 0
     },
     {
       description: 'Take another Wronged move',
-      type: 'Improvements::AnotherMove',
+      type: 'Improvements::PlaybookMove',
       playbook: @wronged,
       # Used to differentiate (and initially hide this) from the identical improvement above.
       stat_limit: -1


### PR DESCRIPTION
## Description of Feature or Issue
closes #112 

:card_file_box:  `wronged.seeds.rb` seed data.

## Thoughts/Issues/Questions
:construction:  "DIY Surgery" 7-9 roll description includes inline bullet points, vs. embedding HTML newlines in the database
:construction:  Gear: "Sawn-off shotgun" has a "hand/close" tag -- should these be separated, vs. one?
:construction:  Gear: Do signature weapons and practical weapons need a differentiable property?
:construction:  Improvement: "Create a second hunter to play as well with this one" needs a type
:construction:  Improvement: "Mark two of the basic moves as advanced" & "Mark another two of the basic moves as advanced" -- should these diverge from the manual to have the same name with `stat_limit: 0|-1`?
:construction:  Improvement: "You track down the specific monster(s) responsible for your loss. The Keeper must make the next mystery about them" needs a type
:construction:  Improvement: "Change the target of your vengeful rage. Pick a new monster breed: I know my prey now applies to them instead." needs a type

## Tangential Changes
:memo:  Added `docker-compose` command to reset the DB w/ seed file to the contributing doc
:bug:  `chosen.seeds.rb`: Weird and Tough improvements had their ratings switched
:pencil2:  `chosen.seeds.rb`: Converted smart-quote for consistency and to avoid encoding issues

## User-Facing Changes
![image](https://user-images.githubusercontent.com/796596/94997875-08674000-057c-11eb-965d-20612caf2c96.png)