### PR TITLE
Lint fixes: set dependent option

### DIFF
--- a/app/models/hunter.rb
+++ b/app/models/hunter.rb
@@ -34,7 +34,7 @@ class Hunter < ApplicationRecord
   has_many :moves, through: :hunters_moves
   accepts_nested_attributes_for :moves
 
-  has_many :hunters_improvements
+  has_many :hunters_improvements, dependent: :destroy
   validates_associated :hunters_improvements,
                        message: lambda { |_class_obj, obj|
                                   obj[:value]&.map { |h_improv| h_improv.errors.full_messages.to_sentence }&.join(', ')

--- a/app/models/playbook.rb
+++ b/app/models/playbook.rb
@@ -13,9 +13,9 @@
 # The class or playbook that the hunter has
 # provides unique abilities to the Hunter
 class Playbook < ApplicationRecord
-  has_many :improvements
-  has_many :gears
-  has_many :moves
+  has_many :improvements, dependent: :destroy
+  has_many :gears, dependent: :destroy
+  has_many :moves, dependent: :destroy
   has_many :ratings, dependent: :destroy
   validates :name, presence: true
 end


### PR DESCRIPTION
if playbook is destroyed, then destroy:
- improvements
- gears
- moves
if hunter is destroyed, then destroy hunters_improvements

## Description of Feature or Issue
closes #68 

## User-Facing Changes
none

## Under-the-Hood Changes
added `dependent: :destroy` where it was missing.
I assume that without a hunter, then their improvements are meaningless and should be destroyed as well.
Similarly, if a playbook is destroy, it didn't look like their related improvements, gears, or moves were meaningful.  Please correct me if I'm wrong.

Cool project.