### PR TITLE
161-cannot-create-new-hunters

### DIFF
--- a/app/controllers/hunters_controller.rb
+++ b/app/controllers/hunters_controller.rb
@@ -42,6 +42,8 @@ class HuntersController < ApplicationController
   def create
     @hunter = Hunter.new(hunter_params)
     @hunter.user = current_user
+    @hunter.assign_attributes(experience: 0, harm: 0, luck: 7)
+
     respond_to do |format|
       if @hunter.save
         format.html { redirect_to hunter_path(@hunter), notice: 'Hunter was successfully created.' }


### PR DESCRIPTION
## Description of Feature or Issue
The call to Hunter.new(hunter_params) was called within create but the values of experience, harm and luck were all nil failing the models validations. This addition assigns the attributes after the hunter_params have been assigned overwritting the nil values.
closes #161 

This is using `assign_attributes` but if there is a more performant way please let me know! 🤔

<!-- You are encouraged, but not required to use Gitmoji in your PR https://gitmoji.carloscuesta.me/ -->
## User-Facing Changes
N/A

This resolves the issue, though it might be worth creating a test to check that Hunters cannot be created if the required attributes are nil. 🙂