### PR TITLE
Tests for required hunter attributes added on create

### DIFF
--- a/spec/models/hunter_spec.rb
+++ b/spec/models/hunter_spec.rb
@@ -138,4 +138,23 @@ RSpec.describe Hunter, type: :model do
       it { is_expected.to be_falsey }
     end
   end
+
+  describe '#create' do
+    context 'hunter will not be valid if required attributes are nil' do
+      let(:hunter) { build :hunter, harm: nil, luck: nil }
+
+      it { expect(hunter).to_not be_valid }
+    end
+
+    context 'returns validation errors when required attributes are nil' do
+      let(:hunter) { build :hunter, harm: nil, luck: nil }
+
+      it do
+        hunter.save
+
+        expect(hunter.errors.messages[:harm]).to eq(["is not a number"])
+        expect(hunter.errors.messages[:luck]).to eq(["is not a number"])
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description of Feature or Issue
Harm and Luck are required Hunter attributes added on create and the validations are currently untested as they cannot be nil. This is in relation to the change made here as the attributes from new was being overwritten. https://github.com/ChaelCodes/HuntersKeepers/pull/185

## Under-the-Hood Changes
Added check for whether model is valid when required attributes Harm and Luck are nil and that validation errors are triggered