### PR TITLE
Controller test for required hunter attributes added on create

### DIFF
--- a/spec/controllers/hunters_controller_spec.rb
+++ b/spec/controllers/hunters_controller_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe HuntersController, type: :controller do
       hunter: {
         name: 'Killua',
         playbook_id: create(:playbook).id,
-        harm: nil,
-        luck: nil
+        harm: 8,
+        luck: 0
       }
     }
   end
@@ -126,14 +126,29 @@ RSpec.describe HuntersController, type: :controller do
       let(:attributes) { valid_attributes }
 
       it 'creates a new Hunter' do
-        expect(attributes[:hunter][:harm]).to eq 0
-        expect(attributes[:hunter][:luck]).to eq 7
         expect { post_create }.to change(Hunter, :count).by(1)
       end
 
       it 'redirects to the created hunter' do
         post_create
         expect(response).to redirect_to(Hunter.last)
+      end
+    end
+
+    context 'when provided nil harm and luck which are required attributes' do
+      let(:attributes) { valid_attributes }
+      let(:hidden_attributes_from_form) { {"harm": nil, "luck": nil} }
+
+      it 'nil attributes are overwritten to defaults and creates a new Hunter' do
+        attributes = valid_attributes[:hunter].merge(hidden_attributes_from_form)
+
+        expect(attributes[:harm]).to eq nil
+        expect(attributes[:luck]).to eq nil
+
+        expect { post_create }.to change(Hunter, :count).by(1)
+
+        expect(controller.params[:hunter][:harm]).to eq "0"
+        expect(controller.params[:hunter][:luck]).to eq "7"
       end
     end
 

--- a/spec/controllers/hunters_controller_spec.rb
+++ b/spec/controllers/hunters_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe HuntersController, type: :controller do
         name: 'Ruudii',
         playbook_id: create(:playbook).id,
         harm: 0,
-        luck: 0,
+        luck: 7,
         charm: 1,
         cool: 1,
         sharp: 0,
@@ -27,8 +27,8 @@ RSpec.describe HuntersController, type: :controller do
       hunter: {
         name: 'Killua',
         playbook_id: create(:playbook).id,
-        harm: 8,
-        luck: 0
+        harm: nil,
+        luck: nil
       }
     }
   end
@@ -126,6 +126,8 @@ RSpec.describe HuntersController, type: :controller do
       let(:attributes) { valid_attributes }
 
       it 'creates a new Hunter' do
+        expect(attributes[:hunter][:harm]).to eq 0
+        expect(attributes[:hunter][:luck]).to eq 7
         expect { post_create }.to change(Hunter, :count).by(1)
       end
 

--- a/spec/models/hunter_spec.rb
+++ b/spec/models/hunter_spec.rb
@@ -138,23 +138,4 @@ RSpec.describe Hunter, type: :model do
       it { is_expected.to be_falsey }
     end
   end
-
-  describe '#create' do
-    context 'hunter will not be valid if required attributes are nil' do
-      let(:hunter) { build :hunter, harm: nil, luck: nil }
-
-      it { expect(hunter).to_not be_valid }
-    end
-
-    context 'returns validation errors when required attributes are nil' do
-      let(:hunter) { build :hunter, harm: nil, luck: nil }
-
-      it do
-        hunter.save
-
-        expect(hunter.errors.messages[:harm]).to eq(["is not a number"])
-        expect(hunter.errors.messages[:luck]).to eq(["is not a number"])
-      end
-    end
-  end
 end

--- a/spec/models/hunter_spec.rb
+++ b/spec/models/hunter_spec.rb
@@ -138,4 +138,23 @@ RSpec.describe Hunter, type: :model do
       it { is_expected.to be_falsey }
     end
   end
+
+  describe '#create' do
+    context 'hunter will not be valid if required attributes are nil' do
+      let(:hunter) { build :hunter, harm: nil, luck: nil }
+
+      it { expect(hunter).to_not be_valid }
+    end
+
+    context 'returns validation errors when required attributes are nil' do
+      let(:hunter) { build :hunter, harm: nil, luck: nil }
+
+      it do
+        hunter.save
+
+        expect(hunter.errors.messages[:harm]).to eq(["is not a number"])
+        expect(hunter.errors.messages[:luck]).to eq(["is not a number"])
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description of Feature or Issue
This is a follow up to a closed pull request here [#188](https://github.com/ChaelCodes/HuntersKeepers/pull/188) in which it was
decided that the default values of harm and luck are set within the create method when passed initially as nil should instead be tested within the controller.  🙌

## Under-the-Hood Changes
 Harm and Luck are required Hunter attributes added on create and the validations are currently untested as they cannot be nil. This is in relation to the change made here as the attributes from new was being overwritten.  [#185](https://github.com/ChaelCodes/HuntersKeepers/pull/185) 

As discussed previously this method of testing is new to me and if there is anything I have misinterpreted or could do better please let me know and I will make amendments! 🙂