### PR TITLE
Excluded json.jbuilder files from magic comment rubocop check

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,3 +40,7 @@ Style/DoubleNegation:
 
 Style/EmptyCaseCondition:
   Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - 'app/views/**/*.json.jbuilder'

--- a/app/views/hunter_backstories/_hunter_backstory.json.jbuilder
+++ b/app/views/hunter_backstories/_hunter_backstory.json.jbuilder
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 json.extract! hunter_backstory, :id, :hunter, :playbook, :choices,
               :created_at, :updated_at
 json.url url_for(hunter_backstory, format: :json)

--- a/app/views/hunter_backstories/index.json.jbuilder
+++ b/app/views/hunter_backstories/index.json.jbuilder
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 json.array! @hunter_backstories,
             partial: 'hunter_backstories/hunter_backstory',
             as: :hunter_backstory

--- a/app/views/hunter_backstories/show.json.jbuilder
+++ b/app/views/hunter_backstories/show.json.jbuilder
@@ -1,4 +1,2 @@
-# frozen_string_literal: true
-
 json.partial! 'hunter_backstories/hunter_backstory',
               hunter_backstory: @hunter_backstory


### PR DESCRIPTION
## Description of Feature or Issue
closes #202
![image](https://user-images.githubusercontent.com/57972448/104787690-73b0d880-574d-11eb-80dc-7a5c0e86b64c.png)

  <!-- Put the issue number here and the issue will be automatically closed when the PR is merged -->

:adhesive_bandage: <--- This is supposed to be an adhesive bandage 🤔<!-- You are encouraged, but not required to use Gitmoji in your PR https://gitmoji.carloscuesta.me/ -->
## User-Facing Changes
N/A
<!-- Please include screenshots -->

## Under-the-Hood Changes
Added new script to rubocop.yml file to exclude json.jbuilder file extension from magic comment rule.