### PR TITLE
Use Luck Effect from Playbook

### DIFF
--- a/app/controllers/moves_controller.rb
+++ b/app/controllers/moves_controller.rb
@@ -26,6 +26,7 @@ class MovesController < ApplicationController
     # TODO: raise complaint id unrollable
     return unless hunter && @move.rollable?
     roll_results = if params[:lucky]
+                     @luck_effect = hunter.playbook.luck_effect
                      @move.lucky_roll(hunter, params[:lose_experience])
                    else
                      @move.roll_results(hunter)

--- a/app/controllers/playbooks_controller.rb
+++ b/app/controllers/playbooks_controller.rb
@@ -73,6 +73,6 @@ class PlaybooksController < ApplicationController
   # Never trust parameters from the scary internet,
   # only permit the allow list through.
   def playbook_params
-    params.require(:playbook).permit(:name, :description, :config)
+    params.require(:playbook).permit(:name, :description, :luck_effect, :config)
   end
 end

--- a/app/javascript/components/hunter_move.vue
+++ b/app/javascript/components/hunter_move.vue
@@ -17,6 +17,7 @@
           :count="2"
         ></b-skeleton>
         <p v-show="!loading">{{ moveDescription || move.description }}</p>
+        <p v-show="usedLuck && !loading">{{ luckEffect }}</p>
       </div>
     </div>
     <div class="card-footer">
@@ -50,22 +51,25 @@ export default {
     return {
       isOpen: false,
       loading: false,
+      luckEffect: "",
       moveDescription: "",
       rollResult: 12,
+      usedLuck: false,
     };
   },
   methods: {
     roll(lucky = false, loseExp = false) {
+      this.usedLuck = false;
       this.loading = true;
       this.isOpen = true;
       if (this.move.seven_to_nine) {
-        console.log(this.moveUrl(lucky, loseExp));
         fetch(this.moveUrl(lucky, loseExp))
           .then((response) => response.json())
           .then((move_resp) => {
             this.loading = false;
             this.moveDescription = move_resp["results"];
             this.rollResult = move_resp["roll"];
+            this.luckEffect = move_resp["luck_effect"];
           });
       } else {
         this.loading = false;
@@ -85,6 +89,7 @@ export default {
     },
     useLuck(loseExp) {
       this.roll(true, loseExp);
+      this.usedLuck = true;
     },
   },
   name: "HunterMove",

--- a/app/models/playbook.rb
+++ b/app/models/playbook.rb
@@ -7,6 +7,7 @@
 #  id          :bigint           not null, primary key
 #  config      :jsonb
 #  description :string
+#  luck_effect :string
 #  name        :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null

--- a/app/views/moves/roll.json.jbuilder
+++ b/app/views/moves/roll.json.jbuilder
@@ -3,3 +3,4 @@
 json.partial! 'moves/move', move: @move
 json.results @results
 json.roll @roll
+json.luck_effect @luck_effect

--- a/app/views/playbooks/_form.html.erb
+++ b/app/views/playbooks/_form.html.erb
@@ -3,6 +3,7 @@
 
   <%= form.labelled_text_field :name %>
   <%= form.labelled_text_field :description %>
+  <%= form.labelled_text_field :luck_effect %>
   <%= form.labelled_text_area :config %>
 
   <div class="actions">

--- a/app/views/playbooks/_playbook.json.jbuilder
+++ b/app/views/playbooks/_playbook.json.jbuilder
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-json.extract! playbook, :id, :name, :description, :created_at, :updated_at
+json.extract! playbook, :id, :name, :description, :luck_effect, :created_at, :updated_at
 json.url playbook_url(playbook, format: :json)

--- a/app/views/playbooks/show.html.erb
+++ b/app/views/playbooks/show.html.erb
@@ -8,6 +8,10 @@
         <li><%= display_rating(rating) %></li>
       <% end %>
     </ul>
+    <% if @playbook.luck_effect %>
+      <p><%= t('.luck_effect_html', playbook_name: @playbook.name, luck_effect: @playbook.luck_effect) %></p>
+    <% end %>
+
     <h4 class="subtitle is-4" style="margin-top:1rem; margin-bottom:.5rem"><%= @playbook.backstory[:name] %></h4>
     <% @playbook.backstory[:headings].each do |heading| %>
       <h5 class="subtitle is-5" style="margin-top:1rem; margin-bottom:.5rem"><%= heading[:name] %></h5>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,3 +37,6 @@ en:
       success: "Hunter backstory was successfully updated."
     destroy:
       success: "Hunter backstory was successfully destroyed."
+  playbooks:
+    show:
+      luck_effect_html: "<strong>%{playbook_name} Special:</strong> %{luck_effect}"

--- a/db/migrate/20210124152645_add_luck_effect_to_playbooks.rb
+++ b/db/migrate/20210124152645_add_luck_effect_to_playbooks.rb
@@ -1,0 +1,5 @@
+class AddLuckEffectToPlaybooks < ActiveRecord::Migration[6.0]
+  def change
+    add_column :playbooks, :luck_effect, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_27_145200) do
+ActiveRecord::Schema.define(version: 2021_01_24_152645) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -121,6 +121,7 @@ ActiveRecord::Schema.define(version: 2020_12_27_145200) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "config"
+    t.string "luck_effect"
   end
 
   create_table "ratings", force: :cascade do |t|

--- a/spec/controllers/moves_controller_spec.rb
+++ b/spec/controllers/moves_controller_spec.rb
@@ -173,7 +173,8 @@ RSpec.describe MovesController, type: :controller do
               get_roll
               expect(body).to include(
                 roll: 13,
-                results: 'Your total 13 resulted in ten plus result'
+                results: 'Your total 13 resulted in ten plus result',
+                luck_effect: hunter.playbook.luck_effect
               )
             end
 

--- a/spec/controllers/playbooks_controller_spec.rb
+++ b/spec/controllers/playbooks_controller_spec.rb
@@ -146,14 +146,17 @@ RSpec.describe PlaybooksController, type: :controller do
     let(:user) { create :user, :admin }
 
     context 'with valid params' do
-      let(:attributes) { { name: 'The Unnamed' } }
+      let(:attributes) { { name: 'The Unnamed', luck_effect: 'This is LUCK' } }
 
       context 'when html format' do
         let(:format_type) { :html }
 
         it 'updates the requested playbook' do
           put_update
-          expect(playbook.reload.name).to eq 'The Unnamed'
+          expect(playbook.reload).to have_attributes({
+            name: 'The Unnamed',
+            luck_effect: 'This is LUCK'
+          })
         end
 
         it 'redirects to the playbook' do

--- a/spec/factories/playbooks.rb
+++ b/spec/factories/playbooks.rb
@@ -7,6 +7,7 @@
 #  id          :bigint           not null, primary key
 #  config      :jsonb
 #  description :string
+#  luck_effect :string
 #  name        :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null

--- a/spec/factories/playbooks.rb
+++ b/spec/factories/playbooks.rb
@@ -15,7 +15,8 @@
 FactoryBot.define do
   factory :playbook do
     name { 'The Nameless' }
-    description { 'A nameless playbook for a namelees entity.' }
+    description { 'A nameless playbook for a nameless entity.' }
+    luck_effect { 'When you spend a point of Luck, lose a point of luck.' }
 
     trait :with_backstory do
       config { {backstory: {name: "Fate", headings: [{name: "How you found out.", count: 1, choices: ["Nightmares and visions", "Some weirdo told you."]  }]}

--- a/spec/features/hunters/show_spec.rb
+++ b/spec/features/hunters/show_spec.rb
@@ -36,4 +36,23 @@ describe 'hunters#show' do
       expect(page).to have_content(basic_move.name)
     end
   end
+
+  context 'with rollable playbook moves' do
+    let!(:moves_rollable) { create(:moves_rollable, name: 'The Rollable Move') }
+
+    before { hunter.moves << moves_rollable }
+
+    it 'uses luck to change the outcome', js: true do
+      visit "/hunters/#{hunter.id}".dup
+      within('#moves') do
+      find('.card-header-title').click
+        expect(page).to have_content("(weird #{hunter.weird})")
+      end
+      expect(Random).to receive(:new).and_return(instance_double('Random', rand: 0))
+      find(".card-footer-item").click
+      expect(page).to have_content "Your total #{hunter.weird}"
+      click_on("Use Luck")
+      expect(page).to have_content "Your total #{hunter.weird + 12}"
+    end
+  end
 end

--- a/spec/features/playbooks/edit_spec.rb
+++ b/spec/features/playbooks/edit_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'playbooks#edit' do
+  let(:user) { create :user, :admin }
+  let!(:playbook) { create :playbook, luck_effect: 'Is lucky' }
+
+  before :each do
+    sign_in user
+    visit "/playbooks/#{playbook.id}/edit".dup
+  end
+
+  it 'edits the playbook' do
+    expect(page).to have_content 'Editing Playbook'
+    fill_in 'playbook[luck_effect]', with: 'This is a luck effect.'
+    click_button 'Update Playbook'
+      expect(page).to have_content('Playbook was successfully updated.')
+      expect(playbook.reload).to have_attributes(
+        luck_effect: 'This is a luck effect.'
+      )
+  end
+
+  context 'with regular user' do
+    let(:user) { create :user }
+
+    it 'prevents user from accessing edit' do
+      expect(page).to have_content 'You are not authorized to perform this action.'
+    end
+  end
+end

--- a/spec/features/playbooks/show_spec.rb
+++ b/spec/features/playbooks/show_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'playbooks#show' do
+  let(:user) { create :user }
+  let!(:playbook) { create :playbook, luck_effect: 'Is lucky' }
+
+  before :each do
+    sign_in user
+  end
+
+  it 'shows the playbook luck effect' do
+    visit "/playbooks/#{playbook.id}".dup
+    expect(page).to have_content('Is lucky')
+  end
+end

--- a/spec/models/playbook_spec.rb
+++ b/spec/models/playbook_spec.rb
@@ -5,6 +5,7 @@
 #  id          :bigint           not null, primary key
 #  config      :jsonb
 #  description :string
+#  luck_effect :string
 #  name        :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null


### PR DESCRIPTION
- Add luck_effect attribute to Playbook
- When the hunter uses luck, display the playbook's luck effect.

fixes #

## Description of Changes

## Screenshots

## Problem Solved

## PR Checklist
- [ ] Unit test coverage?
- [ ] Code Climate Passes? (Reach out to @ChaelCodes if checks need dismissing)
- [ ] Example Seed file if new data table introduced?
