### PR TITLE
enh: Update Docker config.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -38,4 +38,3 @@ coverage/
 spec/tmp
 **.orig
 .bundle
-node_modules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,13 @@ If you cannot use Docker, start by ensuring your development environment is read
 ### Docker
 You can run the app locally (Postgres + Webpacker + Rails) via a Docker container.
 
+Before you begin, there are a few setup commands:
+
+```
+> docker-compose run --rm web yarn install --check-files
+> docker-compose run --rm web rails db:test:prepare db:prepare
+```
+
 Executing `docker-compose up` will bring those services up, and the application will be accessible via `http://localhost:3000`.
 
 The initial run will create two Docker volumes, one for the database and one for the Node modules.
@@ -50,16 +57,16 @@ Note: this requires that you've given the Docker application access to that fold
 
 ### Helpful Docker Commands
 To open the Rails console:\
-`docker exec -it hunterskeepers_web_1 bin/rails c`
+`docker-compose run --rm web bin/rails c`
 
 To open the Postgres console:\
-`docker exec -it hunterskeepers_db_1 psql -U postgres hunterskeepers_development`
+`docker-compose exec db psql -U postgres hunterskeepers_development`
 
 To run your tests:\
-`docker exec -it hunterskeepers_web_1 bundle exec rspec`
+`docker-compose run --rm web bundle exec rspec`
 
 To run rubocop:\
-`docker exec -it hunterskeepers_web_1 bundle exec rubocop`
+`docker-compose run --rm web bundle exec rubocop`
 
 To reset the database with the seed data:
 1. (If server was running) Shut down the web server: `docker-compose stop web`
@@ -77,7 +84,5 @@ web_1           | ========================================
 
 If you update package.json or yarn.lock you'll want to rebuild that module. There might be a more efficient way, but you can run:
 ```
-> docker-compose build node_modules
-> docker-compose run node_modules
-> docker-compose up
+> docker-compose run --rm web yarn install --check-files
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,15 +28,6 @@ RUN bundle install --quiet -j4 --retry 3 \
     && find /usr/local/bundle/gems/ -name "*.c" -delete \
     && find /usr/local/bundle/gems/ -name "*.o" -delete
 
-# Expose port 5000 from the final image.
-# This is important if you deploy to Gitlab, otherwise it does
-# not matter which port we use here.
-EXPOSE 5000
-
-# When starting this container, run the rails server
-# binding to all IP's, and port 5000.
-CMD bundle exec rails server -b 0.0.0.0 -p 5000
-
 # This image is used to build assets and delete side effects.
 # This will **include** development and test gems.
 FROM rails-builder AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,117 @@
-FROM ruby:2.7.2
+# Generating a generic Rails image.
+# Just for caching.
+FROM ruby:2.7-alpine AS rails
 
-# 1. Configuring apt to properly install yarn
-# 2. Installing node, postgres-client, yarn
-# 3. Clearing apt-cached files to tighten the image size
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add - \
-  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
-  && apt-get update -qq \
-  && apt-get install -y build-essential \
-  nodejs \
-  yarn \
-  && rm -rf /var/lib/apt/lists/*
+# `apk` is like `apt`, but for Alpine Linux.
+RUN apk add --update --no-cache --quiet \
+    build-base \
+    nodejs-current \
+    postgresql-dev \
+    sqlite-dev \
+    tzdata \
+    yarn
 
+# Create a generic Gemfile with only Rails.
+RUN echo -e "source 'https://rubygems.org'\ngem 'rails'" > /Gemfile
+# Install Rails, quietly, in 4 threads.
+RUN bundle install --quiet -j4
+
+# Uses the image above as the base for a builder image.
+# This will **exclude** development and testing gems.
+FROM rails as rails-builder
+
+# Set the value of `pwd` for all following operations.
+WORKDIR /app/
+
+# Add the Gemfile and Gemfile.lock from this application.
+COPY Gemfile Gemfile.lock /app/
+
+# Configure bundle to freeze gems.
+RUN bundle config --global frozen 1 \
+    # Installs gems, quietly, in 4 threads, and retry if broken.
+    && bundle install --quiet -j4 --retry 3 \
+    # Remove unneeded files (cached *.gem, *.o, *.c)
+    && rm -rf /usr/local/bundle/cache/*.gem \
+    && find /usr/local/bundle/gems/ -name "*.c" -delete \
+    && find /usr/local/bundle/gems/ -name "*.o" -delete
+
+# Expose port 5000 from the final image.
+# This is important if you deploy to Gitlab, otherwise it does
+# not matter which port we use here.
+EXPOSE 5000
+
+# When starting this container, run the rails server
+# binding to all IP's, and port 5000.
+CMD bundle exec rails server -b 0.0.0.0 -p 5000
+
+# This image is used to build assets and delete side effects.
+# This will **include** development and test gems.
+FROM rails-builder AS builder
+
+# Copy in the Gemfile and Gemfile.lock files in.
+COPY Gemfile Gemfile.lock /app/
+# Delete the existing bundle.
+RUN rm -rf /usr/local/bundle \
+    # Configure bundle to freeze gems.
+    && bundle config --global frozen 1 \
+    # Configure bundle to exclude development and test environments.
+    && bundle config set without 'development test' \
+    # Installs gems, quietly, in 4 threads, and retry if broken.
+    && bundle install --quiet -j4 --retry 3 \
+    # Remove unneeded files (cached *.gem, *.o, *.c)
+    && rm -rf /usr/local/bundle/cache/*.gem \
+    && find /usr/local/bundle/gems/ -name "*.c" -delete \
+    && find /usr/local/bundle/gems/ -name "*.o" -delete
+
+# Add the npm package.json and yarn.lock to install packages.
+COPY package.json yarn.lock /app/
+# Use yarn to install node dependencies.
+RUN yarn install
+
+# Copy in everything from the current directory.
+COPY ./ /app/
+
+# Compile assets in Production mode.
+RUN RAILS_ENV=production SECRET_KEY_BASE=not_for_prod bundle exec rake assets:precompile
+
+# Clean up temporary files.
+RUN rm -rf node_modules tmp/cache vendor/assets lib/assets spec
+
+# Final, production, image.  Minimum footprint.
+FROM ruby:2.7-alpine AS final
+
+# Set rails to production mode.
+ENV RAILS_ENV production
+# Tell Rails to log to STDOUT so it shows in Docker logs.
+ENV RAILS_LOG_TO_STDOUT true
+# Tell Rails to server static files, rather than using a
+# reverse proxy. 
+ENV RAILS_SERVE_STATIC_FILES true
+# Tell Rails not to worry about the ExecJS Runtime, since
+# the assets are already compiled.
+ENV EXECJS_RUNTIME Disabled
+
+# Still need postgres libraries and timezone data.
+RUN apk add --update --no-cache postgresql-client tzdata
+
+# Add the user `app` so we are not running privileged.
+RUN addgroup -g 1000 -S app \
+    && adduser -u 1000 -S app -G app
+
+# Switch to the user named `app`.  All following commands
+# will be run as the `app` user.
+USER app
+
+# Change our working directory to /app
 WORKDIR /app
 
-# Bundling
-COPY Gemfile* ./
-RUN gem install bundler:2.1.4 && bundle install
+# Copy gems from the builder image to this image.
+COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 
-# Building /node_modules
-COPY yarn.lock .
-COPY package.json .
-RUN yarn install --check-files
+# Copy the compiled app (with assets) from the builder image
+# to this image.
+COPY --from=builder --chown=app:app /app /app
 
-# Loads a snapshot of the application files into the image.
-COPY . .
-
-# Rails App is Setup
-
+# When starting this container, run the rails server
+# binding to all IP's, and port 5000.
+CMD bundle exec rails server -b 0.0.0.0 -p 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,8 @@ WORKDIR /app/
 # Add the Gemfile and Gemfile.lock from this application.
 COPY Gemfile Gemfile.lock /app/
 
-# Configure bundle to freeze gems.
-RUN bundle config --global frozen 1 \
-    # Installs gems, quietly, in 4 threads, and retry if broken.
-    && bundle install --quiet -j4 --retry 3 \
+# Installs gems, quietly, in 4 threads, and retry if broken.
+RUN bundle install --quiet -j4 --retry 3 \
     # Remove unneeded files (cached *.gem, *.o, *.c)
     && rm -rf /usr/local/bundle/cache/*.gem \
     && find /usr/local/bundle/gems/ -name "*.c" -delete \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --update --no-cache --quiet \
     build-base \
     nodejs-current \
     postgresql-dev \
+    python2 \
     tzdata \
     yarn
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,17 +7,11 @@ RUN apk add --update --no-cache --quiet \
     build-base \
     nodejs-current \
     postgresql-dev \
-    sqlite-dev \
     tzdata \
     yarn
 
-# Create a generic Gemfile with only Rails.
-RUN echo -e "source 'https://rubygems.org'\ngem 'rails'" > /Gemfile
-# Install Rails, quietly, in 4 threads.
-RUN bundle install --quiet -j4
-
 # Uses the image above as the base for a builder image.
-# This will **exclude** development and testing gems.
+# This will **include** development and testing gems.
 FROM rails as rails-builder
 
 # Set the value of `pwd` for all following operations.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,44 +7,33 @@ services:
       POSTGRES_DB: hunterskeepers_development
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
-      DB_HOST: db
     volumes:
-      - "data:/var/lib/postgresql/data"
+      - data:/var/lib/postgresql/data
     ports:
       - "5432"
-
-  # Initializes the named volume with an appropriate /node_modules
-  node_modules:
-    build: .
-    volumes:
-      - "node:/app/node_modules/"
-    command: bash -c "yarn install --check-files"
-
   webpacker:
-    depends_on:
-      - node_modules
-    build: .
+    build:
+      context: .
+      target: rails-builder
     environment:
       - NODE_ENV=development
       - RAILS_ENV=development
       - WEBPACKER_DEV_SERVER_HOST=0.0.0.0
     command: ./bin/webpack-dev-server
     volumes:
-      - "./:/app/"
-      # :nocopy so this service won't try to copy the image's /node_modules into the volume
-      - "node:/app/node_modules/:nocopy"
+      - ./:/app/
     ports:
       - "3035:3035"
 
   web:
-    container_name: "hunterskeepers_web"
+    build:
+      context: .
+      target: rails-builder
     depends_on:
       - chrome
       - db
-      - node_modules
       - webpacker
-    build: .
-    command: bash -c "
+    command: sh -c "
       bundle exec rake db:migrate db:seed
       && rm -f tmp/pids/server.pid
       && bundle exec rails s -p 3000 -b '0.0.0.0'
@@ -54,8 +43,6 @@ services:
       - "3000:3000"
     volumes:
       - "./:/app/"
-      # :nocopy so this service won't try to copy the image's /node_modules into the volume
-      - "node:/app/node_modules/:nocopy"
     environment:
       - WEBPACKER_DEV_SERVER_HOST=webpacker
       - POSTGRES_USER=postgres
@@ -71,5 +58,3 @@ services:
 volumes:
   # Volume to hold the Postgres database on the host system
   data:
-  # Volume to hold the container-appropriate node_modules/ on the host system
-  node:


### PR DESCRIPTION
## Description of Feature or Issue
closes #220 

## Under-the-Hood Changes

This change updates the `Dockerfile` and `docker-compose.yml` (and some documentation) to reflect my understanding of best practices for Rails, Node, and general development.

### Multi-stage Dockerfile

A large change to the `Dockerfile` is the conversion to a Multi-Stage build.  If you understand Multi-Stage builds, you can probably skip this section.

Multi-Stage build `Dockerfile` is a Dockerfile which uses multiple `FROM` statements.  This allows the final image shipped to production to be as small as possible, while still implementing the environments required for Development.  

For more information on Multi-stage builds, check out [the official docs](https://docs.docker.com/develop/develop-images/multistage-build/).

### Dockerfile

The `Dockerfile` has four stages:

1. `rails` - Used as a base image so that most of the Rails pre-reqs are cached for the other stages.
2. `rails-builder` - Used as a base image for this application, which should be used during development.  Has all of this applications requirements installed.
3. `builder` - Used for building the static assets so that Node does not need to be installed in the final image.  This image only includes the production gems.
4. `final` - The production image.
  - Creates a distinct user named `app` so Rails is not running as a privileged user.
  - Copies Gems from the `builder` stage.
  - Copies `/app` from the `builder` stage, which includes pre-compiled assets.
  - Sets a `CMD` so that the image can run without a command being specified.

The final image comes down to 106MB from 650MB in the `rails-builder` stage, and 1.22GB from the previous image.

### Docker Compose

The `docker-compose.yml` changes are mostly based on my experience, so I **very much welcome feedback**.  

#### node_modules

I removed `node_modules` because I have found that not having a valid local copy of `node_modules/` has a negative impact on development.  Firstly, by not having a copy of `node_modules/` in your development workspace, editor Intellisense fails, or does not act correctly.

In addition, I worry about confusion if you install the Node modules locally, as well as in the container.  Two copies also means that developers must remember to update their dependencies in both environments.  I believe there also exists a few specialized node modules which act differently in Windows vs. *nix.

The negative trade off is that `yarn install` must be run manually when the repo is first cloned, or when adding new packages.

#### pg

In `pg` I removed the `DB_HOST` variable which is not listed as a configuration in the Postgres image.

#### webpacker

Removed dependency on `node_modules`.  Changed `build` to use the `rails-builder` stage of the `Dockerfile`.  Removed mapping of `node_modules/` from the `node` volume.

#### web

Changed `build` to use the `rails-builder` stage of the `Dockerfile`.  Updated to use `sh` instead of `bash`, so that the command will work with the Alpine Linux used as the base for the Docker images.  Removed mapping for `node_modules/`.

