### PR TITLE
Add New Relic Performance Monitoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,10 @@ group :test do
   gem 'selenium-webdriver'
 end
 
+group :production do
+  gem 'newrelic_rpm'
+end
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,7 @@ GEM
     mini_portile2 (2.5.0)
     minitest (5.14.2)
     msgpack (1.3.3)
+    newrelic_rpm (6.15.0)
     nio4r (2.5.4)
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
@@ -289,6 +290,7 @@ DEPENDENCIES
   i18n
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  newrelic_rpm
   pg (>= 0.18, < 2.0)
   pry-rails
   puma (~> 3.12)

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -1,0 +1,47 @@
+#
+# This file configures the New Relic Agent.  New Relic monitors Ruby, Java,
+# .NET, PHP, Python, Node, and Go applications with deep visibility and low
+# overhead.  For more information, visit www.newrelic.com.
+#
+# Generated February 10, 2021
+#
+# This configuration file is custom generated for NewRelic Administration
+#
+# For full documentation of agent configuration options, please refer to
+# https://docs.newrelic.com/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration
+
+common:
+  &default_settings # Required license key associated with your New Relic account.
+  license_key: 73ac2fa0d21ec823330cee3795150ccc8a97NRAL
+
+  # Your application name. Renaming here affects where data displays in New
+  # Relic.  For more details, see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/renaming-applications
+  app_name: HuntersKeepers
+
+  distributed_tracing:
+    enabled: true
+
+  # To disable the agent regardless of other settings, uncomment the following:
+  # agent_enabled: false
+
+  # Logging level for log/newrelic_agent.log
+  log_level: info
+
+# Environment-specific settings are in this section.
+# RAILS_ENV or RACK_ENV (as appropriate) is used to determine the environment.
+# If your application has other named environments, configure them here.
+development:
+  <<: *default_settings
+  app_name: HuntersKeepers (Development)
+
+test:
+  <<: *default_settings
+  # It doesn't make sense to report to New Relic from automated test runs.
+  monitor_mode: false
+
+staging:
+  <<: *default_settings
+  app_name: HuntersKeepers (Staging)
+
+production:
+  <<: *default_settings


### PR DESCRIPTION
## Description of Changes
- Add newrelic_rpm gem
- Add newrelic.yml config

## Problem Solved
New Relic provides observability, performance moritoring, and exception tracking. Right now it's hard to tell which endpoints are slow in HuntersKeepers (and I know I have n+1 queries). I also don't have any visisbility into errors unless they're reported through GitHub. This tracking should help with that.

## PR Checklist
- [ ] Unit test coverage?
- [ ] Code Climate Passes? (Reach out to @ChaelCodes if checks need dismissing)
- [ ] Example Seed file if new data table introduced?
