### PR TITLE
Duplicate Config to Backstory - Rename Config to Backstory

### DIFF
--- a/app/models/playbook.rb
+++ b/app/models/playbook.rb
@@ -26,8 +26,8 @@ class Playbook < ApplicationRecord
     name
   end
 
-  def backstory
-    return nil unless config
-    # JSON.parse(config)['backstory'].with_indifferent_access
+  def config=(val)
+    self.backstory = val
+    super(val)
   end
 end

--- a/app/models/playbook.rb
+++ b/app/models/playbook.rb
@@ -7,6 +7,7 @@
 # Table name: playbooks
 #
 #  id          :bigint           not null, primary key
+#  backstory   :jsonb
 #  config      :jsonb
 #  description :string
 #  luck_effect :string

--- a/app/views/playbooks/show.html.erb
+++ b/app/views/playbooks/show.html.erb
@@ -12,15 +12,7 @@
       <p><%= t('.luck_effect_html', playbook_name: @playbook.name, luck_effect: @playbook.luck_effect) %></p>
     <% end %>
 
-    <h4 class="subtitle is-4" style="margin-top:1rem; margin-bottom:.5rem"><%= @playbook.backstory&.dig(:name) %></h4>
-    <% @playbook.backstory&.dig(:headings)&.each do |heading| %>
-      <h5 class="subtitle is-5" style="margin-top:1rem; margin-bottom:.5rem"><%= heading[:name] %></h5>
-      <ul>
-      <% heading[:choices].each do |choice| %>
-        <li><%= choice %></li>
-      <% end %>
-      </ul>
-    <% end %>
+    <h4 class="subtitle is-4" style="margin-top:1rem; margin-bottom:.5rem"><%= @playbook.backstory %></h4>
     <%= show_page_buttons(@playbook) %>
   </div>
   <div class="column">

--- a/db/migrate/20210214163413_rename_backstory.rb
+++ b/db/migrate/20210214163413_rename_backstory.rb
@@ -1,0 +1,5 @@
+class RenameBackstory < ActiveRecord::Migration[6.0]
+  def change
+    add_column :playbooks, :backstory, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_24_152645) do
+ActiveRecord::Schema.define(version: 2021_02_14_163413) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -122,6 +122,7 @@ ActiveRecord::Schema.define(version: 2021_01_24_152645) do
     t.datetime "updated_at", null: false
     t.jsonb "config"
     t.string "luck_effect"
+    t.jsonb "backstory"
   end
 
   create_table "ratings", force: :cascade do |t|

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -8,4 +8,12 @@ namespace :data do
       .update_all(description: 'Retire this hunter to safety.', # rubocop:disable Rails/SkipsModelValidations
                   type: 'Improvements::Retire')
   end
+
+  # We're renaming config to backstory
+  desc 'Copy everything in Config to Backstory'
+  task copy_from_config_to_backstory: :environment do
+    Playbook.in_batches do |playbooks|
+      playbooks.update_all('backstory = config')
+    end
+  end
 end

--- a/spec/factories/playbooks.rb
+++ b/spec/factories/playbooks.rb
@@ -5,6 +5,7 @@
 # Table name: playbooks
 #
 #  id          :bigint           not null, primary key
+#  backstory   :jsonb
 #  config      :jsonb
 #  description :string
 #  luck_effect :string

--- a/spec/models/playbook_spec.rb
+++ b/spec/models/playbook_spec.rb
@@ -3,6 +3,7 @@
 # Table name: playbooks
 #
 #  id          :bigint           not null, primary key
+#  backstory   :jsonb
 #  config      :jsonb
 #  description :string
 #  luck_effect :string


### PR DESCRIPTION
## Description of Feature or Issue
The first stage of renaming config to backstory is duplicating the column with a new name.

We want to create a second column to hold the new data. Then we'll make sure changes stay in sync by copying changes to both records. Lastly, we'll copy all the data from config to backstory in a rake task so the copy doesn't hold up the deploy queue like it would in a migration.

<!-- You are encouraged, but not required to use Gitmoji in your PR https://gitmoji.carloscuesta.me/ -->
## User-Facing Changes
I had to remove some backstory code that was generating errors due to a name conflict. I reused the backstory name. If I hadn't, I wouldn't've needed to remove it.

## Under-the-Hood Changes
- Added new column to Playbook: backstory
- `config=(val)` copies to backstory as well
- added rake task `data:copy_from_config_to_backstory` that copies data from config to backstory

## After-Merge
- [ ] run `bundle exec rake data:copy_from_config_to_backstory` in the Heroku console