### PR TITLE
Remove Config Column - Rename config to backstory

### DIFF
--- a/app/models/playbook.rb
+++ b/app/models/playbook.rb
@@ -8,7 +8,6 @@
 #
 #  id          :bigint           not null, primary key
 #  backstory   :jsonb
-#  config      :jsonb
 #  description :string
 #  luck_effect :string
 #  name        :string

--- a/app/models/playbook.rb
+++ b/app/models/playbook.rb
@@ -21,8 +21,6 @@ class Playbook < ApplicationRecord
   has_many :ratings, dependent: :destroy
   validates :name, presence: true
 
-  self.ignored_columns = [:config]
-
   def to_s
     name
   end

--- a/db/migrate/20210214201600_remove_config_from_playbooks.rb
+++ b/db/migrate/20210214201600_remove_config_from_playbooks.rb
@@ -1,0 +1,5 @@
+class RemoveConfigFromPlaybooks < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :playbooks, :config, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_14_163413) do
+ActiveRecord::Schema.define(version: 2021_02_14_201600) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -120,7 +120,6 @@ ActiveRecord::Schema.define(version: 2021_02_14_163413) do
     t.string "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.jsonb "config"
     t.string "luck_effect"
     t.jsonb "backstory"
   end

--- a/spec/factories/playbooks.rb
+++ b/spec/factories/playbooks.rb
@@ -6,7 +6,6 @@
 #
 #  id          :bigint           not null, primary key
 #  backstory   :jsonb
-#  config      :jsonb
 #  description :string
 #  luck_effect :string
 #  name        :string

--- a/spec/models/playbook_spec.rb
+++ b/spec/models/playbook_spec.rb
@@ -4,7 +4,6 @@
 #
 #  id          :bigint           not null, primary key
 #  backstory   :jsonb
-#  config      :jsonb
 #  description :string
 #  luck_effect :string
 #  name        :string


### PR DESCRIPTION
## Description of Feature or Issue
FINALLY! We can remove config from the database, and be certain we won't trigger issues.

<!-- You are encouraged, but not required to use Gitmoji in your PR https://gitmoji.carloscuesta.me/ -->
## User-Facing Changes
None!

## Under-the-Hood Changes
- Removed `config` column from `playbooks` table
- Removed `ignored_columns`