### PR TITLE
Exclude Devise from Pundit verify checks

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   include Pundit
   protect_from_forgery with: :exception
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
-  after_action :verify_authorized, except: :index
+  after_action :verify_authorized, except: :index, unless: :devise_controller?
   default_form_builder ApplicationFormBuilder
 
   def check_for_mobile


### PR DESCRIPTION
## Description of Changes
Excluse devise controllers from Pundit verify checks.

## Problem Solved
HuntersKeepers is currently down because Pundit has authorization checks that verify authorize was called by the end of a controller method. Devise controller methods do not make these calls, so they were all raising errors.

## PR Checklist
- [ ] Unit test coverage?
- [ ] Code Climate Passes? (Reach out to @ChaelCodes if checks need dismissing)
- [ ] Example Seed file if new data table introduced?
