### PR TITLE
Clean up unwanted Improvements

### DIFF
--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -16,4 +16,11 @@ namespace :data do
       playbooks.update_all('backstory = config')
     end
   end
+
+  desc 'Delete unauthorized record creation'
+  task delete_unauth_improvements: :environment do
+    Improvement.where("created_at >  to_timestamp('15 Feb 2021', 'DD Mon YYYY')")
+               .where("created_at < to_timestamp('18 Feb 2021', 'DD Mon YYYY')")
+               .delete_all
+  end
 end


### PR DESCRIPTION
## Description of Changes
Add new rake task that removes all improvements created between Feb 15th, 2021, and Feb 18th, 2021.

## Problem Solved
On Feb 16th, we discovered unauthorized users could create Improvements and other rules without logging in. We investigated the data and removed several Playbooks that were unauthorized. The only other examples we saw were Improvements. A large number of improvements were created and are removed by this rake task.

## PR Checklist
- [ ] Unit test coverage?
- [ ] Code Climate Passes? (Reach out to @ChaelCodes if checks need dismissing)
- [ ] Example Seed file if new data table introduced?
