### PR TITLE
Allow admins to delete playbooks

### DIFF
--- a/app/controllers/playbooks_controller.rb
+++ b/app/controllers/playbooks_controller.rb
@@ -56,7 +56,7 @@ class PlaybooksController < ApplicationController
   # DELETE /playbooks/1
   # DELETE /playbooks/1.json
   def destroy
-    @playbook.destroy
+    @playbook.archive!
     respond_to do |format|
       format.html { redirect_to playbooks_url, notice: t('.success') }
       format.json { head :no_content }

--- a/app/models/playbook.rb
+++ b/app/models/playbook.rb
@@ -27,9 +27,9 @@ class Playbook < ApplicationRecord
   has_many :moves, dependent: :destroy
   has_many :ratings, dependent: :destroy
   validates :name, presence: true
-  
+
   default_scope { unarchived }
-  scope :unarchived, -> { where(archived_at: nil ) } 
+  scope :unarchived, -> { where(archived_at: nil) } 
 
   def archive!
     self.archived_at ||= Time.zone.now

--- a/app/models/playbook.rb
+++ b/app/models/playbook.rb
@@ -29,10 +29,10 @@ class Playbook < ApplicationRecord
   validates :name, presence: true
   
   default_scope { unarchived }
-  scope :unarchived, -> { where(archived_at: nil)} 
+  scope :unarchived, -> { where(archived_at: nil )} 
 
   def archive!
-    self.archived_at ||= Time.now
+    self.archived_at ||= Time.zone.now
     save
   end
 

--- a/app/models/playbook.rb
+++ b/app/models/playbook.rb
@@ -29,7 +29,7 @@ class Playbook < ApplicationRecord
   validates :name, presence: true
 
   default_scope { unarchived }
-  scope :unarchived, -> { where(archived_at: nil) } 
+  scope :unarchived, -> { where(archived_at: nil) }
 
   def archive!
     self.archived_at ||= Time.zone.now

--- a/app/models/playbook.rb
+++ b/app/models/playbook.rb
@@ -27,6 +27,14 @@ class Playbook < ApplicationRecord
   has_many :moves, dependent: :destroy
   has_many :ratings, dependent: :destroy
   validates :name, presence: true
+  
+  default_scope { unarchived }
+  scope :unarchived, -> { where(archived_at: nil)} 
+
+  def archive!
+    self.archived_at ||= Time.now
+    save
+  end
 
   def to_s
     name

--- a/app/models/playbook.rb
+++ b/app/models/playbook.rb
@@ -29,7 +29,7 @@ class Playbook < ApplicationRecord
   validates :name, presence: true
   
   default_scope { unarchived }
-  scope :unarchived, -> { where(archived_at: nil )} 
+  scope :unarchived, -> { where(archived_at: nil ) } 
 
   def archive!
     self.archived_at ||= Time.zone.now

--- a/app/views/playbooks/index.html.erb
+++ b/app/views/playbooks/index.html.erb
@@ -14,7 +14,7 @@
   <tbody>
     <% @playbooks.each do |playbook| %>
       <tr>
-        <td><%= link_to playbook.name, playbook %></td>
+        <td><%= link_to playbook %></td>
         <% unless mobile_device? %>
           <td><%= playbook.description.truncate(100, separator: ' ') %></td>
         <% end %>

--- a/db/migrate/20210223184452_add_archived_at_to_playbooks.rb
+++ b/db/migrate/20210223184452_add_archived_at_to_playbooks.rb
@@ -1,0 +1,5 @@
+class AddArchivedAtToPlaybooks < ActiveRecord::Migration[6.0]
+  def change
+    add_column :playbooks, :archived_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_14_201600) do
+ActiveRecord::Schema.define(version: 2021_02_23_184452) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -122,6 +122,7 @@ ActiveRecord::Schema.define(version: 2021_02_14_201600) do
     t.datetime "updated_at", null: false
     t.string "luck_effect"
     t.jsonb "backstory"
+    t.datetime "archived_at"
   end
 
   create_table "ratings", force: :cascade do |t|

--- a/spec/controllers/playbooks_controller_spec.rb
+++ b/spec/controllers/playbooks_controller_spec.rb
@@ -239,7 +239,9 @@ RSpec.describe PlaybooksController, type: :controller do
 
         it 'destroys the requested playbook' do
           playbook
-          expect { delete_destroy }.to change(Playbook, :count).by(-1)
+          delete_destroy
+          playbook.reload
+          expect(playbook.archived_at).not_to be_nil
         end
 
         it 'redirects to the playbooks list' do

--- a/spec/models/playbook_spec.rb
+++ b/spec/models/playbook_spec.rb
@@ -26,6 +26,59 @@ RSpec.describe Playbook, type: :model do
     expect(playbook).to be_valid
   end
 
+  describe '#archive!' do
+    before do
+      allow(Time).to receive(:now)
+                 .and_return(Time.parse("2021-02-23 19:21:00"))
+      playbook.archive! 
+    end
+
+    it 'sets the archived date' do
+      expect(playbook.archived_at).not_to be_nil
+    end
+
+    context 'with created playbook' do
+      let(:playbook) { create :playbook }
+
+      it 'retains the archived_at' do
+        expect(playbook.reload.archived_at).not_to be_nil
+      end
+    end
+
+    context 'when playbook has already been archived' do
+      let(:date) { Time.parse('2021-02-20 19:21:00') }
+      let(:playbook) { build :playbook, archived_at: date }
+
+      it "doesn't overwrite existing archived_at" do
+        expect(playbook.archived_at).to eq date
+      end
+    end
+  end
+
+  describe '.unarchived' do
+    subject { Playbook.unarchived }
+    let(:date) { Time.parse('2021-02-20 19:21:00') }
+    let!(:archived) { create :playbook, archived_at: date }
+    let!(:unarchived) { create :playbook }
+
+    it 'only unarchived values' do
+      is_expected.to include unarchived
+      is_expected.not_to include archived
+    end
+  end
+
+  describe '.all' do
+    subject { Playbook.all }
+    let(:date) { Time.parse('2021-02-20 19:21:00') }
+    let!(:archived) { create :playbook, archived_at: date }
+    let!(:unarchived) { create :playbook }
+
+    it 'only unarchived values' do
+      is_expected.to include unarchived
+      is_expected.not_to include archived
+    end
+  end
+
   # describe '#backstory' do
   #   subject { playbook.backstory }
   #   let(:playbook) { build :playbook, :with_backstory }


### PR DESCRIPTION
## Description of Feature or Issue
closes #213  <!-- Put the issue number here and the issue will be automatically closed when the PR is merged -->
Admins were not able to delete playbooks, because of foreign key references. Instead we'll archive playbooks, so new Hunters can't add them.

"New Relic saved my life" <!-- You are encouraged, but not required to use Gitmoji in your PR https://gitmoji.carloscuesta.me/ -->
## User-Facing Changes
<!-- Please include screenshots -->

## Under-the-Hood Changes

Added archived_at column
Replaced the destroy method call within the destroy method in the Playbooks Controller to new `archive!` method 
Added `default_scope` that added `unarchived` and applied as a default scope
