### PR TITLE
Improve the speed of the gears/index

### DIFF
--- a/app/controllers/gears_controller.rb
+++ b/app/controllers/gears_controller.rb
@@ -8,7 +8,7 @@ class GearsController < ApplicationController
   # GET /gears.json
   def index
     @hunter = Hunter.find(params[:hunter_id]) if params[:hunter_id]
-    @gears = Gear.all
+    @gears = Gear.includes(:playbook)
   end
 
   # GET /gears/1

--- a/app/views/gears/index.html.erb
+++ b/app/views/gears/index.html.erb
@@ -9,7 +9,6 @@
       <th>Description</th>
       <th>Harm</th>
       <th>Armor</th>
-      <th>Tags</th>
       <th>Playbook</th>
       <th colspan="3"></th>
     </tr>
@@ -22,7 +21,6 @@
         <td><%= gear.description %></td>
         <td><%= gear.harm %></td>
         <td><%= gear.armor %></td>
-        <td><%= gear.tag_list %></td>
         <td><%= link_to_playbook(gear) %></td>
         <td><%= link_to 'Show', gear %></td>
         <td><%= link_to 'Edit', edit_gear_path(gear) %></td>

--- a/spec/factories/gears.rb
+++ b/spec/factories/gears.rb
@@ -38,6 +38,7 @@ FactoryBot.define do
     trait :with_tags do
       after(:create) do |gear|
         gear.tag_list = %w(heavy slow)
+        gear.save
       end
     end
   end

--- a/spec/features/gears/index_spec.rb
+++ b/spec/features/gears/index_spec.rb
@@ -10,7 +10,6 @@ describe 'gears#index' do
       expect(row).to have_content 'Description'
       expect(row).to have_content 'Harm'
       expect(row).to have_content 'Armor'
-      expect(row).to have_content 'Tags'
       expect(row).to have_content 'Playbook'
     end
     page.all('tbody > tr').each do |row|

--- a/spec/features/gears/index_spec.rb
+++ b/spec/features/gears/index_spec.rb
@@ -12,8 +12,6 @@ describe 'gears#index' do
       expect(row).to have_content 'Armor'
       expect(row).to have_content 'Playbook'
     end
-    page.all('tbody > tr').each do |row|
-      expect(row).to have_content 'Sword'
-    end
+    expect(page).to have_content 'Sword'
   end
 end

--- a/spec/features/gears/index_spec.rb
+++ b/spec/features/gears/index_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe 'gears#index' do
+  let!(:gear) { create_list :gear, 3, :with_tags }
+
+  it 'has a list of gears' do
+    visit "/gears"
+    page.all('thead > tr').each do |row|
+      expect(row).to have_content 'Name'
+      expect(row).to have_content 'Description'
+      expect(row).to have_content 'Harm'
+      expect(row).to have_content 'Armor'
+      expect(row).to have_content 'Tags'
+      expect(row).to have_content 'Playbook'
+    end
+    page.all('tbody > tr').each do |row|
+      expect(row).to have_content 'Sword'
+    end
+  end
+end


### PR DESCRIPTION
## Description of Changes

- Create consistent test for gears index for Benchmarking
- Tag_list was responsible for slow loading on the gears index, because it was an N+1.
- Include Playbook to reduce the number of N+1 queries

## Screenshots

## Problem Solved

New Relic showed us that Gears/Index was our slowest endpoint, and that the cause was Acts as Taggable On, and N+1 queries on Playbooks.

## PR Checklist
- [x] Unit test coverage?
- [ ] Code Climate Passes? (Reach out to @ChaelCodes if checks need dismissing)
- [ ] Example Seed file if new data table introduced?
