### PR TITLE
Fix link to Playbook on Index

### DIFF
--- a/app/views/playbooks/index.html.erb
+++ b/app/views/playbooks/index.html.erb
@@ -14,7 +14,7 @@
   <tbody>
     <% @playbooks.each do |playbook| %>
       <tr>
-        <td><%= link_to playbook %></td>
+        <td><%= link_to playbook, playbook %></td>
         <% unless mobile_device? %>
           <td><%= playbook.description.truncate(100, separator: ' ') %></td>
         <% end %>

--- a/spec/features/playbooks/index_spec.rb
+++ b/spec/features/playbooks/index_spec.rb
@@ -19,6 +19,13 @@ describe 'playbooks#index' do
       expect(page).to have_content 'The Nameless'
       expect(page).not_to have_content('Destroy')
     end
+
+    it 'the name takes me to the show page' do
+      visit '/playbooks'
+      expect(page).to have_link 'The Nameless', href: "/playbooks/#{playbook.id}"
+      click_on 'The Nameless'
+      expect(page).to have_current_path "/playbooks/#{playbook.id}"
+    end
   end
 
   context 'playbook with a backstory' do


### PR DESCRIPTION
fixes #249

## Description of Changes
The link to a playbook's show page on the Playbook index now works, instead of linking to root.

## PR Checklist
- [x] Unit test coverage?
- [ ] Code Climate Passes? (Reach out to @ChaelCodes if checks need dismissing)
- [ ] Example Seed file if new data table introduced?
