### PR TITLE
Fix Query for Moves to include all Moves

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -53,8 +53,11 @@ class Move < ApplicationRecord
       .where(hunters: { id: hunter_id })
   end
   scope :include_hunter_moves, ->(hunter_id) do # rubocop:disable Style/Lambda
+    query = %(LEFT JOIN hunters_moves on
+              hunters_moves.hunter_id = #{hunter_id}
+              AND moves.id = hunters_moves.move_id)
     includes(:hunters_moves)
-      .where(hunters_moves: { hunter_id: [hunter_id, nil] })
+      .joins(query)
   end
   scope :haven, -> { where(haven: true) }
 

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -48,15 +48,21 @@ RSpec.describe Move, type: :model do
     subject { described_class.include_hunter_moves(hunter.id) }
 
     let!(:move) { create :move }
+    let!(:move1) { create :move }
     let(:hunter) { create :hunter }
     let(:hunters_move) { HuntersMove.first }
 
     context 'when target hunter has move' do
-      before { hunter.moves << move }
+      before { hunter.moves << [move, move1] }
 
       it 'includes the hunter move associated with target hunter' do
         expect(subject.pluck(:'hunters_moves.id', :'moves.id'))
           .to include [hunters_move.id, move.id]
+      end
+
+      it 'does not duplicate moves' do
+        expect(subject.where('moves.id': move.id).count)
+          .to eq 1
       end
     end
 
@@ -75,6 +81,8 @@ RSpec.describe Move, type: :model do
       it 'does not include other hunters hunters_moves' do
         expect(subject.pluck(:'hunters_moves.id', :'moves.id'))
           .not_to include [hunters_move.id, move.id]
+        expect(subject.pluck(:'hunters_moves.id', :'moves.id'))
+          .to include [nil, move.id]
       end
     end
   end


### PR DESCRIPTION
## Description of Changes
- Fix query for Moves that include hunters_moves
- Playbook is more helpful than type

## Screenshots

## Problem Solved
The where clause we used to filter hunter moves was also removing any move that had been used by any hunter. We replaced it with a left join, and now all moves are seen, and only hunters moves for that specific hunter are checked.

## PR Checklist
- [ ] Unit test coverage?
- [ ] Code Climate Passes? (Reach out to @ChaelCodes if checks need dismissing)
- [ ] Example Seed file if new data table introduced?
