### PR TITLE
Add Hunter reference guide to the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -20,3 +20,5 @@ Dev team to add solution that we'd like to implement here.
 
 **References**
 Any references to materials or help articles that may help in implementing this issue.
+
+- [Hunter/Playbook Reference](https://www.evilhat.com/home/wp-content/uploads/2019/03/Monster-of-the-Week-Revised-Playbooks.pdf)


### PR DESCRIPTION
## Description of Feature or Issue
Link to Hunter Reference sheet inside every issue by default.

## User-Facing Changes
The contributer/maintainer will have access to the playbook rules in the issue.
