### PR TITLE
Fix stray backslashes and whitespace

### DIFF
--- a/db/seeds/move.seeds.rb
+++ b/db/seeds/move.seeds.rb
@@ -2,545 +2,419 @@
 
 [{
   name: 'Manipulate Someone',
-  description: 'Once you have given them a reason, tell
-them what you want them to do and roll
-+Charm',
+  description: 'Once you have given them a reason, tell '\
+  'them what you want them to do and roll '\
+  '+Charm',
   rating: 'charm',
   six_and_under: "Failure. Keeper's choice.",
-  seven_to_nine: 'On a 7-9, they’ll do it, but only if
-you do something for them right
-now to show that you mean it. If
-you asked too much, they’ll tell
-you what, if anything, it would
-take for them to do it.',
-  ten_plus: 'On a 10+, then they’ll do it for
-the reason you gave them. If you
-asked too much, they’ll tell you the
-minimum it would take for them
-to do it (or if there’s no way they’d
-do it).',
-  twelve_plus: 'On a 12+ not only do
-they do what you want right now,
-they also become your ally for the
-rest of the mystery (or, if you do
-enough for them, permanently).'
+  seven_to_nine: 'On a 7-9, they’ll do it, but only if '\
+  'you do something for them right '\
+  'now to show that you mean it. If '\
+  'you asked too much, they’ll tell '\
+  'you what, if anything, it would '\
+  'take for them to do it.',
+  ten_plus: 'On a 10+, then they’ll do it for '\
+  'the reason you gave them. If you '\
+  'asked too much, they’ll tell you the '\
+  'minimum it would take for them '\
+  'to do it (or if there’s no way they’d '\
+  'do it).',
+  twelve_plus: 'On a 12+ not only do '\
+  'they do what you want right now, '\
+  'they also become your ally for the '\
+  'rest of the mystery (or, if you do '\
+  'enough for them, permanently).'
 },
  {
    name: 'Act Under Pressure',
-   description: 'When you act under pressure, roll
-+Cool.',
+   description: 'When you act under pressure, roll +Cool.',
    rating: 'cool',
    six_and_under: "Failure. Keeper's choice.",
-   seven_to_nine: 'On a 7-9 the Keeper is going to give
-you a worse outcome, hard choice, or
-price to pay.',
+   seven_to_nine: 'On a 7-9 the Keeper is going to give '\
+   'you a worse outcome, hard choice, or '\
+   'price to pay.',
    ten_plus: 'On a 10+ you do what you set out to.',
-   twelve_plus: 'On a 12+ you may
-choose to either do what you wanted
-and something extra, or to do what you
-wanted to absolute perfection.'
+   twelve_plus: 'On a 12+ you may choose to either do what you wanted '\
+   'and something extra, or to do what you wanted to absolute perfection.'
  },
  {
    name: 'Help Out',
-   description: 'When you help another hunter, roll
-+Cool.',
+   description: 'When you help another hunter, roll +Cool.',
    rating: 'cool',
    six_and_under: "Failure. Keeper's choice.",
-   seven_to_nine: 'On a 7-9 your help grants them +1 to
-their roll, but you also expose yourself
-to trouble or danger.',
-   ten_plus: 'On a 10+ your help grants them +1
-to their roll.',
-   twelve_plus: 'On a 12+ your help
-lets them act as if they just rolled a 12,
-regardless of what they actually got.'
+   seven_to_nine: 'On a 7-9 your help grants them +1 to '\
+   'their roll, but you also expose yourself '\
+   'to trouble or danger.',
+   ten_plus: 'On a 10+ your help grants them +1 to their roll.',
+   twelve_plus: 'On a 12+ your help '\
+   'lets them act as if they just rolled a 12, '\
+   'regardless of what they actually got.'
  },
  {
    name: 'Investigate a Mystery',
-   description: 'When you investigate a mystery, roll
-+Sharp. On a 10+ hold 2, and on a 7-9
-hold 1. One hold can be spent to ask the
-Keeper one of the following questions:
-• What happened here?
-• What sort of creature is it?
-• What can it do?
-• What can hurt it?
-• Where did it go?
-• What was it going to do?
-• What is being concealed here?',
+   description: 'When you investigate a mystery, roll '\
+   '+Sharp. On a 10+ hold 2, and on a 7-9 '\
+   'hold 1. One hold can be spent to ask the '\
+   "Keeper one of the following questions:\n"\
+   " • What happened here?\n"\
+   " • What sort of creature is it?\n"\
+   " • What can it do?\n"\
+   " • What can hurt it?\n"\
+   " • Where did it go?\n"\
+   " • What was it going to do?\n"\
+   " • What is being concealed here",
    rating: 'sharp',
    six_and_under: "Failure. Keeper's choice.",
-   seven_to_nine: 'You can ask the
-Keeper one of the following questions:
-• What happened here?
-• What sort of creature is it?
-• What can it do?
-• What can hurt it?
-• Where did it go?
-• What was it going to do?
-• What is being concealed here?',
-   ten_plus: 'You can ask the
-Keeper two of the following questions:
-• What happened here?
-• What sort of creature is it?
-• What can it do?
-• What can hurt it?
-• Where did it go?
-• What was it going to do?
-• What is being concealed here?',
-   twelve_plus: 'On a 12+, you may ask the
-Keeper any two questions you want about the
-mystery, not just the listed ones.'
+   seven_to_nine: 'You can ask the '\
+   'Keeper one of the following questions: '\
+   " • What happened here?\n"\
+   " • What sort of creature is it?\n"\
+   " • What can it do?\n"\
+   " • What can hurt it?\n"\
+   " • Where did it go?\n"\
+   " • What was it going to do?\n"\
+   " • What is being concealed here",
+   ten_plus: 'You can ask the '\
+   "Keeper two of the following questions:\n"\
+   " • What happened here?\n"\
+   " • What sort of creature is it?\n"\
+   " • What can it do?\n"\
+   " • What can hurt it?\n"\
+   " • Where did it go?\n"\
+   " • What was it going to do?\n"\
+   ' • What is being concealed here?',
+   twelve_plus: 'On a 12+, you may ask the '\
+   'Keeper any two questions you want about the '\
+   'mystery, not just the listed ones.'
  },
  {
    name: 'Read a Bad Situation',
-   description: 'When you look around and read a bad
-situation, roll +Sharp.',
+   description: 'When you look around and read a bad situation, roll +Sharp.',
    rating: 'sharp',
    six_and_under: "Failure. Keeper's choice.",
-   seven_to_nine: 'Ask the
-Keeper one of the following questions:
-• What’s my best way in?
-• What’s my best way out?
-• Are there any dangers we haven’t
-noticed?
-• What’s the biggest threat?
-• What’s most vulnerable to me?
-• What’s the best way to protect the
-victims?
-If you act on the answers, you get +1
-ongoing while the information is relevant.',
-   ten_plus: 'Ask the
-Keeper any three of the following questions:
-• What’s my best way in?
-• What’s my best way out?
-• Are there any dangers we haven’t
-noticed?
-• What’s the biggest threat?
-• What’s most vulnerable to me?
-• What’s the best way to protect the
-victims?
-If you act on the answers, you get +1
-ongoing while the information is relevant.',
-   twelve_plus: 'You may ask the keeper any three any question you want about
-the situation, not just the listed ones. If you act on the answers, you get +1
-ongoing while the information is relevant.'
+   seven_to_nine: "Ask the Keeper one of the following questions:\n"\
+   " • What’s my best way in?\n"\
+   " • What’s my best way out?\n"\
+   " • Are there any dangers we haven’t noticed?\n"\
+   " • What’s the biggest threat?\n"\
+   " • What’s most vulnerable to me?\n"\
+   " • What’s the best way to protect the victims? "\
+   'If you act on the answers, you get +1 '\
+   'ongoing while the information is relevant.',
+   ten_plus: "Ask the Keeper any three of the following questions:\n"\
+   " • What’s my best way in?\n"\
+   " • What’s my best way out?\n"\
+   " • Are there any dangers we haven’t noticed?\n"\
+   " • What’s the biggest threat?\n"\
+   " • What’s most vulnerable to me?\n"\
+   ' • What’s the best way to protect the victims? '\
+   'If you act on the answers, you get +1 '\
+   'ongoing while the information is relevant.',
+   twelve_plus: 'You may ask the keeper any three any question you want about '\
+   'the situation, not just the listed ones. If you act on the answers, you '\
+   'get +1 ongoing while the information is relevant.'
  },
  {
    name: 'Kick some Ass',
-   description: 'When you get into a fight and kick some
-ass, roll +Tough.',
+   description: 'When you get into a fight and kick some '\
+   'ass, roll +Tough.',
    rating: 'tough',
    six_and_under: 'Failure. You take a beating.',
-   seven_to_nine: 'You and whatever you’re
-fighting inflict harm on each other. The
-amount of harm is based on the established dangers in the game. That usually
-means you inflict the harm rating of
-your weapon and your enemy inflicts
-their attack’s harm rating on you.',
-   ten_plus: 'You and whatever you’re
-fighting inflict harm on each other. The
-amount of harm is based on the established dangers in the game. That usually
-means you inflict the harm rating of
-your weapon and your enemy inflicts
-their attack’s harm rating on you.
-On a 10+, choose one extra effect:
-• You gain the advantage: take +1
-forward, or give +1 forward to
-another hunter.
-• You inflict terrible harm (+1
-harm).
-• You suffer less harm (-1 harm).
-• You force them where you want
-them.',
-   twelve_plus: 'You and whatever you’re
-fighting inflict harm on each other. The
-amount of harm is based on the established dangers in the game. That usually
-means you inflict the harm rating of
-your weapon and your enemy inflicts
-their attack’s harm rating on you.
-On a 12+ instead pick
-an enhanced effect:
-• You completely hold the advantage. All hunters involved in the
-fight get +1 forward.
-• You suffer no harm at all.
-• Your attack inflicts double the
-normal harm.
-• Your attack drives the enemy away
-in a rout.'
+   seven_to_nine: 'You and whatever you’re '\
+   'fighting inflict harm on each other. The '\
+   'amount of harm is based on the established dangers in the game. That usually '\
+   'means you inflict the harm rating of '\
+   'your weapon and your enemy inflicts '\
+   'their attack’s harm rating on you.',
+   ten_plus: 'You and whatever you’re '\
+   'fighting inflict harm on each other. The '\
+   'amount of harm is based on the established dangers in the game. That usually '\
+   'means you inflict the harm rating of '\
+   'your weapon and your enemy inflicts '\
+   'their attack’s harm rating on you. '\
+   "On a 10+, choose one extra effect:\n"\
+   ' • You gain the advantage: take +1 forward, or give +1 forward to another hunter. '\
+   " • You inflict terrible harm (+1 harm).\n"\
+   " • You suffer less harm (-1 harm).\n"\
+   ' • You force them where you want them.',
+   twelve_plus: 'You and whatever you’re '\
+   'fighting inflict harm on each other. The '\
+   'amount of harm is based on the established dangers in the game. That usually '\
+   'means you inflict the harm rating of '\
+   'your weapon and your enemy inflicts '\
+   'their attack’s harm rating on you. '\
+   'On a 12+ instead pick '\
+   "an enhanced effect:\n"\
+   ' • You completely hold the advantage. All hunters involved in the '\
+   'fight get +1 forward. '\
+   " • You suffer no harm at all.\n"\
+   " • Your attack inflicts double the normal harm.\n"\
+   ' • Your attack drives the enemy away in a rout.'
  },
  {
    name: 'Protect Someone',
-   description: 'When you prevent harm to another
-character, roll +Tough',
+   description: 'When you prevent harm to another character, roll +Tough',
    rating: 'tough',
-   six_and_under: "Failure. You fail to preotect them,
-   and you expose yourself to danger.",
-   seven_to_nine: 'You protect them okay, but
-you’ll suffer some or all of the harm they
-were going to get. ',
-   ten_plus: 'You protect them okay, but
-you’ll suffer some or all of the harm they
-were going to get. Choose an extra:
-• You suffer little harm (-1 harm).
-• All impending danger is now
-focused on you.
-• You inflict harm on the enemy.
-• You hold the enemy back.',
-   twelve_plus: 'Both you and
-the character you are protecting are
-unharmed and out of danger. If you
-were protecting a bystander, they also
-become your ally.'
+   six_and_under: 'Failure. You fail to preotect them, '\
+   'and you expose yourself to danger.',
+   seven_to_nine: 'You protect them okay, but '\
+   'you’ll suffer some or all of the harm they '\
+   'were going to get. ',
+   ten_plus: 'You protect them okay, but '\
+   'you’ll suffer some or all of the harm they '\
+   "were going to get. Choose an extra:\n"\
+   " • You suffer little harm (-1 harm).\n"\
+   " • All impending danger is now focused on you.\n"\
+   " • You inflict harm on the enemy.\n"\
+   ' • You hold the enemy back.',
+   twelve_plus: 'Both you and '\
+   'the character you are protecting are '\
+   'unharmed and out of danger. If you '\
+   'were protecting a bystander, they also '\
+   'become your ally.'
  },
  {
    name: 'Use Magic',
-   description: 'When you use magic, say what you’re
-trying to achieve and how you do the
-spell, then roll +Weird.',
+   description: 'When you use magic, say what you’re '\
+   'trying to achieve and how you do the '\
+   'spell, then roll +Weird.',
    rating: 'weird',
    six_and_under: "Failure. Keeper's choice. It is always bad.",
-   seven_to_nine: 'It works imperfectly: choose
-your effect and a glitch. The Keeper will
-decide what effect the glitch has.
-Effects:
-• Inflict harm (1-harm ignorearmour magic obvious).
-• Enchant a weapon. It gets +1 harm
-and +magic.
-• Do one thing that is beyond
-human limitations.
-• Bar a place or portal to a specific
-person or a type of creature.
-• Trap a specific person, minion, or
-monster.
-• Banish a spirit or curse from the
-person, object, or place it inhabits.
-• Summon a monster into the world.
-• Communicate with something
-that you do not share a language
-with.
-• Observe another place or time.
-• Heal 1-harm from an injury, or
-cure a disease, or neutralize a
-poison.
-Glitches:
-• The effect is weakened.
-• The effect is of short duration.
-• You take 1-harm ignore-armour.
-• The magic draws immediate,
-unwelcome attention.
-• It has a problematic side effect.',
-   ten_plus: 'The magic works without
-issues: choose your effect.
-• Inflict harm (1-harm ignorearmour magic obvious).
-• Enchant a weapon. It gets +1 harm
-and +magic.
-• Do one thing that is beyond
-human limitations.
-• Bar a place or portal to a specific
-person or a type of creature.
-• Trap a specific person, minion, or
-monster.
-• Banish a spirit or curse from the
-person, object, or place it inhabits.
-• Summon a monster into the world.
-• Communicate with something
-that you do not share a language
-with.
-• Observe another place or time.
-• Heal 1-harm from an injury, or
-cure a disease, or neutralize a
-poison.',
-   twelve_plus: 'The Keeper
-will offer you some added benefit.
-The magic works without
-issues: choose your effect.
-• Inflict harm (1-harm ignorearmour magic obvious).
-• Enchant a weapon. It gets +1 harm
-and +magic.
-• Do one thing that is beyond
-human limitations.
-• Bar a place or portal to a specific
-person or a type of creature.
-• Trap a specific person, minion, or
-monster.
-• Banish a spirit or curse from the
-person, object, or place it inhabits.
-• Summon a monster into the world.
-• Communicate with something
-that you do not share a language
-with.
-• Observe another place or time.
-• Heal 1-harm from an injury, or
-cure a disease, or neutralize a
-poison.'
+   seven_to_nine: 'It works imperfectly: choose '\
+   'your effect and a glitch. The Keeper will '\
+   'decide what effect the glitch has. '\
+   "Effects:\n"\
+   " • Inflict harm (1-harm ignorearmour magic obvious).\n"\
+   " • Enchant a weapon. It gets +1 harm and +magic.\n"\
+   " • Do one thing that is beyond human limitations.\n"\
+   " • Bar a place or portal to a specific person or a type of creature.\n"\
+   " • Trap a specific person, minion, or monster.\n"\
+   " • Banish a spirit or curse from the person, object, or place it inhabits.\n"\
+   " • Summon a monster into the world.\n"\
+   " • Communicate with something that you do not share a language with.\n"\
+   " • Observe another place or time.\n"\
+   " • Heal 1-harm from an injury, or cure a disease, or neutralize a poison.\n"\
+   "Glitches:\n"\
+   " • The effect is weakened.\n"\
+   " • The effect is of short duration.\n"\
+   " • You take 1-harm ignore-armour.\n"\
+   " • The magic draws immediate, unwelcome attention.\n"\
+   ' • It has a problematic side effect.',
+   ten_plus: 'The magic works without '\
+   "issues: choose your effect.\n"\
+   " • Inflict harm (1-harm ignorearmour magic obvious).\n"\
+   " • Enchant a weapon. It gets +1 harm and +magic.\n"\
+   " • Do one thing that is beyond human limitations.\n"\
+   " • Bar a place or portal to a specific person or a type of creature.\n"\
+   " • Trap a specific person, minion, or monster.\n"\
+   " • Banish a spirit or curse from the person, object, or place it inhabits.\n"\
+   " • Summon a monster into the world.\n"\
+   " • Communicate with something that you do not share a language with.\n"\
+   " • Observe another place or time.\n"\
+   ' • Heal 1-harm from an injury, or '\
+   'cure a disease, or neutralize a '\
+   'poison.',
+   twelve_plus: 'The Keeper '\
+   'will offer you some added benefit. '\
+   'The magic works without '\
+   "issues: choose your effect.\n"\
+   " • Inflict harm (1-harm ignorearmour magic obvious).\n"\
+   " • Enchant a weapon. It gets +1 harm and +magic.\n"\
+   " • Do one thing that is beyond human limitations.\n"\
+   " • Bar a place or portal to a specific person or a type of creature.\n"\
+   " • Trap a specific person, minion, or monster.\n"\
+   " • Banish a spirit or curse from the person, object, or place it inhabits.\n"\
+   " • Summon a monster into the world.\n"\
+   ' • Communicate with something '\
+   'that you do not share a language '\
+   "with.\n"\
+   " • Observe another place or time.\n"\
+   ' • Heal 1-harm from an injury, or cure a disease, or neutralize a '\
+   'poison.'
  },
  {
    name: 'Alt: Empath',
    rating: 'weird',
    six_and_under: 'Your brain is overwhelmed with emotion.',
-   seven_to_nine: 'You gain a hazy impression of their current emotional
-state and intentions.',
-   ten_plus: 'You gain a clear
-impression of their current
-emotional state and intentions.
-Take +1 forward when acting on
-this knowledge.',
-   twelve_plus: 'You get an impression
-(as for 10 or more), and
-you may ask one follow-up question that the Keeper will answer
-honestly.'
+   seven_to_nine: 'You gain a hazy impression of their current emotional '\
+   'state and intentions.',
+   ten_plus: 'You gain a clear impression of their current '\
+   'emotional state and intentions. Take +1 forward when acting on '\
+   'this knowledge.',
+   twelve_plus: 'You get an impression (as for 10 or more), and '\
+   'you may ask one follow-up question that the Keeper will answer '\
+   'honestly.'
  },
  {
    name: 'Alt: Illuminated',
    rating: 'weird',
-   six_and_under: 'The Secret Masters’
-reply is terrible, garbled, or
-somehow dangerously wrong.',
-   seven_to_nine: 'The Secret Masters need
-you to complete a task for them.
-Once it is done, they reveal a key
-fact, clue, or technique that will
-help you.',
-   ten_plus: 'The Secret
-Masters reveal a key fact, clue, or
-technique that will help you.',
-   twelve_plus: 'The Secret
-Masters reveal a key fact, clue,
-or technique that will help you.
-You may ask one follow-up question that the Keeper will answer
-honestly.'
+   six_and_under: 'The Secret Masters’ reply is terrible, garbled, or '\
+   'somehow dangerously wrong.',
+   seven_to_nine: 'The Secret Masters need you to complete a task for them. '\
+   'Once it is done, they reveal a key fact, clue, or technique that will '\
+   'help you.',
+   ten_plus: 'The Secret Masters reveal a key fact, clue, or '\
+   'technique that will help you.',
+   twelve_plus: 'The Secret Masters reveal a key fact, clue, '\
+   'or technique that will help you. You may ask one follow-up '\
+   'question that the Keeper will answer honestly.'
  },
  {
    name: 'Alt: No Limits',
    rating: 'weird',
-   six_and_under: 'Something goes
-horribly wrong.',
-   seven_to_nine: 'You do it but choose
-one consequence: suffer 1-harm,
-take –1 forward, or you need to
-rest right now',
-   ten_plus: 'Your body obeys
-your will, to the limits of physical possibility (see below), for a
-moment.',
-   twelve_plus: 'You can continue
-acting at your body’s limits for 30
-seconds.'
+   six_and_under: 'Something goes horribly wrong.',
+   seven_to_nine: 'You do it but choose one consequence: suffer 1-harm, '\
+   'take –1 forward, or you need to rest right now',
+   ten_plus: 'Your body obeys your will, to the limits of physical '\
+   'possibility (see below), for a moment.',
+   twelve_plus: 'You can continue acting at your body’s limits for 30 seconds.'
  },
  {
    name: 'Alt: Past Lives',
    rating: 'weird',
-   six_and_under: 'A past life takes over
-for a while.',
-   seven_to_nine: 'A past life has a little
-experience with this. Ask the
-Keeper one of the questions below
-• What did a past life discover about
-___________?
-• How did a past life deal with
-__________?
-• What important hidden secret can
-a past life show me the way to?
-• What did a past life learn too late
-to help them?
-• What does a past life advise me to
-do now?',
-   ten_plus: 'A past life has
-something useful to offer. Ask the
-Keeper two of the questions below.
-• What did a past life discover about
-___________?
-• How did a past life deal with
-__________?
-• What important hidden secret can
-a past life show me the way to?
-• What did a past life learn too late
-to help them?
-• What does a past life advise me to
-do now?',
-   twelve_plus: 'A past life knows
-exactly what you were after. Ask
-the Keeper one of the questions
-below, and one free-form question.
-Gain +1 ongoing while acting on
-the answers.
-• What did a past life discover about
-___________?
-• How did a past life deal with
-__________?
-• What important hidden secret can
-a past life show me the way to?
-• What did a past life learn too late
-to help them?
-• What does a past life advise me to
-do now?'
+   six_and_under: 'A past life takes over for a while.',
+   seven_to_nine: 'A past life has a little experience with this. Ask the '\
+   "Keeper one of the questions below\n"\
+   " • What did a past life discover about ___________?\n"\
+   " • How did a past life deal with __________?\n"\
+   " • What important hidden secret can a past life show me the way to?\n"\
+   " • What did a past life learn too late to help them?\n"\
+   " • What does a past life advise me to do now\n",
+   ten_plus: 'A past life has something useful to offer. Ask the '\
+   "Keeper two of the questions below.\n"\
+   " • What did a past life discover about ___________?\n"\
+   " • How did a past life deal with __________?\n"\
+   " • What important hidden secret can a past life show me the way to?\n"\
+   " • What did a past life learn too late to help them?\n"\
+   ' • What does a past life advise me to do now?',
+   twelve_plus: 'A past life knows exactly what you were after. Ask '\
+   'the Keeper one of the questions below, and one free-form question. '\
+   "Gain +1 ongoing while acting on the answers.\n"\
+   " • What did a past life discover about ___________?\n"\
+   " • How did a past life deal with __________?\n"\
+   " • What important hidden secret can a past life show me the way to?\n"\
+   " • What did a past life learn too late to help them?\n"\
+   ' • What does a past life advise me to do now?'
  },
  {
    name: 'Alt: Sentive',
    rating: 'weird',
-   six_and_under: 'Your brain makes
-contact with something dangerous.',
+   six_and_under: 'Your brain makes contact with something dangerous.',
    seven_to_nine: 'You gain a hazy impression about something important.',
-   ten_plus: 'You gain a definite impression (a vision, tangible
-aura, overheard thought, etc) about
-something important.',
-   twelve_plus: 'You get an
-impression as for 10 or more, plus
-you may ask one follow-up question that the Keeper will answer
-honestly.'
+   ten_plus: 'You gain a definite impression (a vision, tangible '\
+   'aura, overheard thought, etc) about something important.',
+   twelve_plus: 'You get an impression as for 10 or more, plus '\
+   'you may ask one follow-up question that the Keeper will answer '\
+   'honestly.'
  },
  {
    name: 'Alt: Trust Your Gut',
    rating: 'weird',
-   six_and_under: 'Your instincts lead you
-into danger',
-   seven_to_nine: 'The Keeper will tell you
-a general direction to go. Take +1
-forward as you explore that.',
-   ten_plus: 'The Keeper will
-tell where you should go. Wherever that is, it will be important.
-You get +1 ongoing on the way to
-this place.',
-   twelve_plus: 'In addition to the
-usual 10+ result, the Keeper will
-tell you about one important thing
-you should investigate further.'
+   six_and_under: 'Your instincts lead you into danger',
+   seven_to_nine: 'The Keeper will tell you a general direction to go. Take +1 '\
+   'forward as you explore that.',
+   ten_plus: 'The Keeper will tell where you should go. Wherever that is, '\
+   'it will be important.  You get +1 ongoing on the way to this place.',
+   twelve_plus: 'In addition to the usual 10+ result, the Keeper will '\
+   'tell you about one important thing you should investigate further.'
  },
  {
    name: 'Alt: Telekinesis',
    rating: 'weird',
-   six_and_under: 'Something goes
-horribly wrong.',
-   seven_to_nine: 'You move it but it hurts.
-Choose one option and mark
-2-harm.
-• Something is held fast.
-• Something is hurt (2-harm smash).
-• Something catches fire.
-• You can fling something bigger
-than a person.
-• You keep it basically under your
-control.
-• You suffer 1 less harm.',
-   ten_plus: 'You move it.
-Choose two options and mark
-1-harm.
-• Something is held fast.
-• Something is hurt (2-harm smash).
-• Something catches fire.
-• You can fling something bigger
-than a person.
-• You keep it basically under your
-control.
-• You suffer 1 less harm.',
-   twelve_plus: 'Choose three
-options. You may also choose from
-the advanced options:
-Normal Options:
-• Something is held fast.
-• Something is hurt (2-harm smash).
-• Something catches fire.
-• You can fling something bigger
-than a person.
-• You keep it basically under your
-control.
-• You suffer 1 less harm.
-Advanced Options:
-• Something explodes (3-harm
-close fire area messy)
-• Something implodes (3-harm
-close crush)
-• Lots of stuff is flying under your
-control.
-• You have perfect and precise
-control over exactly what
-happens.'
+   six_and_under: 'Something goes horribly wrong.',
+   seven_to_nine: "You move it but it hurts.  Choose one option and mark 2-harm.\n"\
+   " • Something is held fast.\n"\
+   " • Something is hurt (2-harm smash).\n"\
+   " • Something catches fire.\n"\
+   " • You can fling something bigger than a person.\n"\
+   " • You keep it basically under your control.\n"\
+   ' • You suffer 1 less harm.',
+   ten_plus: "You move it.  Choose two options and mark 1-harm.\n"\
+   " • Something is held fast.\n"\
+   " • Something is hurt (2-harm smash).\n"\
+   " • Something catches fire.\n"\
+   " • You can fling something bigger than a person.\n"\
+   " • You keep it basically under your control.\n"\
+   ' • You suffer 1 less harm.',
+   twelve_plus: 'Choose three options. You may also choose from '\
+   'the advanced options: '\
+   "Normal Options:\n"\
+   " • Something is held fast.\n"\
+   " • Something is hurt (2-harm smash).\n"\
+   " • Something catches fire.\n"\
+   " • You can fling something bigger than a person.\n"\
+   " • You keep it basically under your control.\n"\
+   " • You suffer 1 less harm.\n"\
+   "Advanced Options:\n"\
+   " • Something explodes (3-harm close fire area messy)\n"\
+   " • Something implodes (3-harm close crush)\n"\
+   " • Lots of stuff is flying under your control.\n"\
+   ' • You have perfect and precise control over exactly what happens.'
  },
  {
    name: 'Alt: Weird Science',
    rating: 'weird',
-   six_and_under: 'Something goes
-horribly wrong. You are still able to
-create your device, but the Keeper
-picks three requirements.
-• It needs a rare and/or weird material.
-• It won’t be very reliable.
-• It requires huge amounts of power
-or fuel.
-• It will take a long time to get it
-working.
-• It won’t work exactly as you
-intended.
-• You’ll need help (beyond the
-hunters on your team) to finish it.',
-   seven_to_nine: 'you pick one requirement and the Keeper picks a
-second one.
-It needs a rare and/or weird material.
-• It won’t be very reliable.
-• It requires huge amounts of power
-or fuel.
-• It will take a long time to get it
-working.
-• It won’t work exactly as you
-intended.
-• You’ll need help (beyond the
-hunters on your team) to finish it.',
-   ten_plus: 'You pick two
-requirements.
-• It needs a rare and/or weird material.
-• It won’t be very reliable.
-• It requires huge amounts of power
-or fuel.
-• It will take a long time to get it
-working.
-• It won’t work exactly as you
-intended.
-• You’ll need help (beyond the
-hunters on your team) to finish it.',
-   twelve_plus: 'On a 12 or more, you gain +1
-ongoing when operating the device.
-• It needs a rare and/or weird material.
-• It won’t be very reliable.
-• It requires huge amounts of power
-or fuel.
-• It will take a long time to get it
-working.
-• It won’t work exactly as you
-intended.
-• You’ll need help (beyond the
-hunters on your team) to finish it.'
+   six_and_under: 'Something goes horribly wrong. You are still able to '\
+   "create your device, but the Keeper picks three requirements.\n"\
+   " • It needs a rare and/or weird material.\n"\
+   " • It won’t be very reliable.\n"\
+   " • It requires huge amounts of power or fuel.\n"\
+   " • It will take a long time to get it working.\n"\
+   " • It won’t work exactly as you intended.\n"\
+   ' • You’ll need help (beyond the hunters on your team) to finish it.',
+   seven_to_nine: 'you pick one requirement and the Keeper picks a second one. '\
+   "It needs a rare and/or weird material.\n"\
+   " • It won’t be very reliable.\n"\
+   " • It requires huge amounts of power or fuel.\n"\
+   " • It will take a long time to get it working.\n"\
+   " • It won’t work exactly as you intended.\n"\
+   ' • You’ll need help (beyond the hunters on your team) to finish it.',
+   ten_plus: "You pick two requirements.\n"\
+   " • It needs a rare and/or weird material.\n"\
+   " • It won’t be very reliable.\n"\
+   " • It requires huge amounts of power or fuel.\n"\
+   " • It will take a long time to get it working.\n"\
+   " • It won’t work exactly as you intended.\n"\
+   " • You’ll need help (beyond the hunters on your team) to finish it",
+   twelve_plus: "On a 12 or more, you gain +1 ongoing when operating the device.\n"\
+   " • It needs a rare and/or weird material.\n"\
+   " • It won’t be very reliable.\n"\
+   " • It requires huge amounts of power or fuel.\n"\
+   " • It will take a long time to get it working.\n"\
+   " • It won’t work exactly as you intended.\n"\
+   ' • You’ll need help (beyond the hunters on your team) to finish it.'
  }].each do |move|
   Moves::Basic.find_or_create_by(move)
 end
 
 [{
   name: 'Lore Library',
-  description: "When you hit the books, take +1 \
-  forward to investigate the mystery (as long as \
-  historical or reference works are appropriate).",
+  description: "When you hit the books, take +1 "\
+  "forward to investigate the mystery (as long as "\
+  "historical or reference works are appropriate).",
   type: 'Moves::Descriptive',
   haven: true
 },
  {
    name: 'Mystical Library',
-   description: "If you use your library’s occult \
-   tomes and grimoires, preparing with your tomes \
-   and grimoires, take +1 forward for use magic.",
+   description: "If you use your library’s occult "\
+   "tomes and grimoires, preparing with your tomes "\
+   "and grimoires, take +1 forward for use magic.",
    type: 'Moves::Descriptive',
    haven: true
  },
  {
    name: 'Protection Spells',
-   description: "Your haven is safe from monsters—they \
-   cannot enter. Monsters might be able to do something \
-   special to evade the wards, but not easily.",
+   description: "Your haven is safe from monsters—they "\
+   "cannot enter. Monsters might be able to do something "\
+   "special to evade the wards, but not easily.",
    type: 'Moves::Descriptive',
    haven: true
  },
  {
    name: 'Armory',
-   description: "You have a stockpile of mystical and \
-   rare monster-killing weapons and items.",
+   description: "You have a stockpile of mystical and "\
+   "rare monster-killing weapons and items.",
    type: 'Moves::Rollable',
    rating: :weird,
    six_and_under: 'On a miss, you’ve got the wrong thing.',
@@ -550,45 +424,45 @@ end
  },
  {
    name: 'Infirmary',
-   description: "You can heal people, and have the space \
-   for one or two to recuperate. The Keeper will tell you \
-   how long any patient’s recovery is likely to take, and \
-   if you need extra supplies or help.",
+   description: "You can heal people, and have the space "\
+   "for one or two to recuperate. The Keeper will tell you "\
+   "how long any patient’s recovery is likely to take, and "\
+   "if you need extra supplies or help.",
    type: 'Moves::Descriptive',
    haven: true
  },
  {
    name: 'Workshop',
-   description: "You have a space for building and repairing \
-   guns, cars and other gadgets. Work out with the Keeper how \
-   long any repair or construction will take, and if you need \
-   extra supplies or help.",
+   description: "You have a space for building and repairing "\
+   "guns, cars and other gadgets. Work out with the Keeper how "\
+   "long any repair or construction will take, and if you need "\
+   "extra supplies or help.",
    type: 'Moves::Descriptive',
    haven: true
  },
  {
    name: 'Oubliette',
-   description: "This room is isolated from every kind of \
-   monster, spirit and magic that you know about. Anything \
-   you stash in there can’t be found, can’t do any magic, \
-   and can’t get out.",
+   description: "This room is isolated from every kind of "\
+   "monster, spirit and magic that you know about. Anything "\
+   "you stash in there can’t be found, can’t do any magic, "\
+   "and can’t get out.",
    type: 'Moves::Descriptive',
    haven: true
  },
  {
    name: 'Panic Room',
-   description: "This has essential supplies and is protected \
-   by normal and mystical means. You can hide out there for a \
-   few days, safe from pretty much anything.",
+   description: "This has essential supplies and is protected "\
+   "by normal and mystical means. You can hide out there for a "\
+   "few days, safe from pretty much anything.",
    type: 'Moves::Descriptive',
    haven: true
  },
  {
    name: 'Magical Library',
-   description: "You have a mystical lab with all kinds \
-   of weird ingredients and tools useful for casting spells \
-   (like the use magic move, big magic, and any other \
-   magical moves).",
+   description: "You have a mystical lab with all kinds "\
+   "of weird ingredients and tools useful for casting spells "\
+   "(like the use magic move, big magic, and any other "\
+   "magical moves).",
    type: 'Moves::Descriptive',
    haven: true
  }].each do |move|
@@ -608,131 +482,118 @@ after :playbook do
     name: 'Get Help from your Sect',
     type: 'Moves::Rollable',
     playbook_id: @initiate.id,
-    description: 'When you are in good standing with your Sect, at
-      the beginning of each mystery, roll +Charm. On
-      a 10+ they provide some useful info or help in the
-      field. On a 7-9 you get a mission associated with the
-      mystery, and if you do it you’ll get some info or help
-      too. On a miss, they ask you to do something bad.
-      If you fail a mission or refuse an order, you’ll be in
-      trouble with the Sect until you atone.',
+    description: 'When you are in good standing with your Sect, at '\
+    'the beginning of each mystery, roll +Charm. On '\
+    'a 10+ they provide some useful info or help in the '\
+    'field. On a 7-9 you get a mission associated with the '\
+    'mystery, and if you do it you’ll get some info or help '\
+    'too. On a miss, they ask you to do something bad. '\
+    'If you fail a mission or refuse an order, you’ll be in '\
+    'trouble with the Sect until you atone.',
     rating: :charm,
-    six_and_under: 'On a miss, they ask you to do something bad.
-      If you fail a mission or refuse an order, you’ll be in
-      trouble with the Sect until you atone.',
-    seven_to_nine: 'On a 7-9 you get a mission associated with the
-      mystery, and if you do it you’ll get some info or help
-      too.',
-    ten_plus: 'On
-      a 10+ they provide some useful info or help in the
-      field.'
+    six_and_under: 'On a miss, they ask you to do something bad. '\
+    'If you fail a mission or refuse an order, you’ll be in '\
+    'trouble with the Sect until you atone.',
+    seven_to_nine: 'On a 7-9 you get a mission associated with the '\
+    'mystery, and if you do it you’ll get some info or help too.',
+    ten_plus: 'On a 10+ they provide some useful info or help in the field.'
   },
    {
      name: 'Ancient Fighting Arts',
      type: 'Moves::Descriptive',
      playbook_id: @initiate.id,
-     description: 'When using an old-fashioned hand weapon, you inflict +1 harm and get +1
-whenever you roll protect someone.'
+     description: 'When using an old-fashioned hand weapon, you inflict +1 '\
+     'harm and get +1 whenever you roll protect someone.'
    },
    {
      name: 'Mystic',
      type: 'Moves::Descriptive',
      playbook_id: @initiate.id,
-     description: 'Every time you successfully use magic, take
-+1 forward.'
+     description: 'Every time you successfully use magic, take +1 forward.'
    },
    {
      name: 'Fortunes',
      type: 'Moves::Rollable',
      playbook_id: @initiate.id,
-     description: 'The Sect has ancient prophecies or divination techniques to predict the future. Once per
-      mystery, you may use them. If you look at what the
-      future holds, roll +Weird. On a 10+ hold 3, and on
-      a 7-9 hold 1. On a miss, you get bad information and
-      the Keeper decides how that affects you. Spend your
-      hold to:
-      • have a useful object ready.
-      • be somewhere you are needed, just in time.
-      • take +1 forward, or give +1 forward to another
-      hunter.
-      • retroactively warn someone about an attack, so
-      that it doesn’t happen.',
+     description: 'The Sect has ancient prophecies or divination techniques '\
+     'to predict the future. Once per mystery, you may use them. If you look '\
+     'at what the future holds, roll +Weird. On a 10+ hold 3, and on '\
+     'a 7-9 hold 1. On a miss, you get bad information and '\
+     "the Keeper decides how that affects you. Spend your hold to:\n"\
+     " • have a useful object ready.\n"\
+     " • be somewhere you are needed, just in time.\n"\
+     " • take +1 forward, or give +1 forward to another hunter.\n"\
+     ' • retroactively warn someone about an attack, so that it doesn’t happen.',
      rating: :weird,
-     six_and_under: 'On a miss, you get bad information and
-      the Keeper decides how that affects you.',
-     seven_to_nine: 'Spend your 1
-      hold to:
-      • have a useful object ready.
-      • be somewhere you are needed, just in time.
-      • take +1 forward, or give +1 forward to another
-      hunter.
-      • retroactively warn someone about an attack, so
-      that it doesn’t happen.',
-     ten_plus: 'Spend your 3
-      hold to:
-      • have a useful object ready.
-      • be somewhere you are needed, just in time.
-      • take +1 forward, or give +1 forward to another
-      hunter.
-      • retroactively warn someone about an attack, so
-      that it doesn’t happen.'
+     six_and_under: 'On a miss, you get bad information and '\
+     'the Keeper decides how that affects you.',
+     seven_to_nine: "Spend your 1 hold to:\n"\
+     " • have a useful object ready.\n"\
+     " • be somewhere you are needed, just in time.\n"\
+     " • take +1 forward, or give +1 forward to another hunter.\n"\
+     ' • retroactively warn someone about an attack, so that it doesn’t happen.',
+     ten_plus: "Spend your 3 hold to:\n"\
+     " • have a useful object ready.\n"\
+     " • be somewhere you are needed, just in time.\n"\
+     " • take +1 forward, or give +1 forward to another hunter.\n"\
+     ' • retroactively warn someone about an attack, so that it doesn’t happen.'
    },
    {
      name: 'Sacred Oath',
      type: 'Moves::Descriptive',
      playbook_id: @initiate.id,
-     description: ' You may bind yourself to a single goal,
-forsaking something during your quest (e.g. speech,
-all sustenance but bread and water, alcohol, lying,
-sex, etc). Get the Keeper’s agreement on this—it
-should match the goal in importance and difficulty.
-While you keep your oath and work towards your
-goal, mark experience at the end of every session
-and get +1 on any rolls that directly help achieve the
-goal. If you break the oath, take -1 ongoing until you
-have atoned.'
+     description: ' You may bind yourself to a single goal, '\
+     'forsaking something during your quest (e.g. speech, '\
+     'all sustenance but bread and water, alcohol, lying, '\
+     'sex, etc). Get the Keeper’s agreement on this—it '\
+     'should match the goal in importance and difficulty. '\
+     'While you keep your oath and work towards your '\
+     'goal, mark experience at the end of every session '\
+     'and get +1 on any rolls that directly help achieve the '\
+     'goal. If you break the oath, take -1 ongoing until you '\
+     'have atoned.'
    },
    {
      name: 'Mentor',
      type: 'Moves::Rollable',
      playbook_id: @initiate.id,
-     description: 'You have a mentor in the Sect: name
-      them. When you contact your mentor for info, roll
-      +Sharp. On a 10+, you get an answer to your question, no problem. On a 7-9 you choose: they’re either
-      busy and can’t help, or they answer the question but
-      you owe a favour. On a miss, your question causes
-      trouble.',
+     description: 'You have a mentor in the Sect: name '\
+     'them. When you contact your mentor for info, roll '\
+     '+Sharp. On a 10+, you get an answer to your question, no problem. On '\
+     'a 7-9 you choose: they’re either '\
+     'busy and can’t help, or they answer the question but '\
+     'you owe a favour. On a miss, your question causes '\
+     'trouble.',
      rating: :sharp,
-     six_and_under: 'On a miss, your question causes
-      trouble.',
-     seven_to_nine: 'On a 7-9 you choose: they’re either
-      busy and can’t help, or they answer the question but
-      you owe a favour.',
+     six_and_under: 'On a miss, your question causes trouble.',
+     seven_to_nine: 'On a 7-9 you choose: they’re either '\
+     'busy and can’t help, or they answer the question but '\
+     'you owe a favour.',
      ten_plus: 'On a 10+, you get an answer to your question, no problem.'
    },
    {
      name: 'Apprentice',
      type: 'Moves::Descriptive',
      playbook_id: @initiate.id,
-     description: 'You have an apprentice: name them.
-      Your job is to teach them the Sect’s ways. They count
-      as an ally: subordinate (motivation: to follow your
-      instructions to the letter).'
+     description: 'You have an apprentice: name them. '\
+     'Your job is to teach them the Sect’s ways. They count '\
+     'as an ally: subordinate (motivation: to follow your '\
+     'instructions to the letter).'
    },
    {
      name: 'Helping Hand',
      type: 'Moves::Descriptive',
      playbook_id: @initiate.id,
-     description: 'When you successfully help out
-      another hunter, they get +2 instead of the usual +1.'
+     description: 'When you successfully help out '\
+     'another hunter, they get +2 instead of the usual +1.'
    },
    {
      name: 'That Old Black Magic',
      type: 'Moves::Descriptive',
      playbook_id: @initiate.id,
-     description: 'When you use magic, you
-      can ask a question from the investigate a mystery
-      move as your effect.'
+     description: 'When you use magic, you '\
+     'can ask a question from the investigate a mystery '\
+     'move as your effect.'
    }].each do |move|
     Move.find_or_create_by!(move)
   end

--- a/db/seeds/move.seeds.rb
+++ b/db/seeds/move.seeds.rb
@@ -73,7 +73,7 @@
    " • What can hurt it?\n"\
    " • Where did it go?\n"\
    " • What was it going to do?\n"\
-   " • What is being concealed here",
+   " • What is being concealed here?",
    ten_plus: 'You can ask the '\
    "Keeper two of the following questions:\n"\
    " • What happened here?\n"\

--- a/db/seeds/playbooks/chosen.seeds.rb
+++ b/db/seeds/playbooks/chosen.seeds.rb
@@ -11,74 +11,73 @@ after :playbook do
     name: "Destiny's Plaything",
     rating: :weird,
     six_and_under: 'On a miss, something bad is going to happen to you.',
-    seven_to_nine: 'On
-  a 7-9 you get a vague hint about the coming mystery.',
-    ten_plus: "On a 10+, the Keeper will
-  reveal a useful detail about the coming mystery.",
+    seven_to_nine: 'On a 7-9 you get a vague hint about the coming mystery.',
+    ten_plus: "On a 10+, the Keeper will reveal a useful detail about the "\
+    "coming mystery.",
     type: 'Moves::Rollable',
     playbook_id: @chosen.id,
-    description: 'At the beginning of each
-  mystery, roll +Weird to see what is revealed about
-  your immediate future.'
+    description: 'At the beginning of each '\
+    'mystery, roll +Weird to see what is revealed about '\
+    'your immediate future.'
   },
    {
      name: "I'm Here For A Reason",
      type: 'Moves::Descriptive',
      playbook_id: @chosen.id,
-     description: 'There’s something you are
-  destined to do. Work out the details with the Keeper,
-  based on your fate. You cannot die until it comes
-  to pass. If you die in play, then you must spend a
-  Luck point. You will then, somehow, recover or be
-  returned to life. Once your task is done (or you use
-  up all your Luck), all bets are off.'
+     description: 'There’s something you are '\
+     'destined to do. Work out the details with the Keeper, '\
+     'based on your fate. You cannot die until it comes '\
+     'to pass. If you die in play, then you must spend a '\
+     'Luck point. You will then, somehow, recover or be '\
+     'returned to life. Once your task is done (or you use '\
+     'up all your Luck), all bets are off.'
    },
    {
      name: 'The Big Entrance',
      rating: :cool,
-     six_and_under: 'On a miss, you’re marked as the
-  biggest threat by all enemies who are present.',
-     seven_to_nine: 'On a 7-9, you pick one
-  person or monster to stop, watch and listen until
-  you finish talking.',
-     ten_plus: 'On 10+ everyone stops to watch and listen until you
-  finish your opening speech.',
+     six_and_under: 'On a miss, you’re marked as the '\
+     'biggest threat by all enemies who are present.',
+     seven_to_nine: 'On a 7-9, you pick one '\
+     'person or monster to stop, watch and listen until '\
+     'you finish talking.',
+     ten_plus: 'On 10+ everyone stops to watch and listen until you '\
+     'finish your opening speech.',
      type: 'Moves::Rollable',
      playbook_id: @chosen.id,
-     description: 'When you make a showy
-  entrance into a dangerous situation, roll +Cool.'
+     description: 'When you make a showy '\
+     'entrance into a dangerous situation, roll +Cool.'
    },
    {
      name: 'Devastating',
      type: 'Moves::Descriptive',
      playbook_id: @chosen.id,
-     description: 'When you inflict harm, you may
-  inflict +1 harm.'
+     description: 'When you inflict harm, you may '\
+     'inflict +1 harm.'
    },
    {
      name: 'Dutiful',
      type: 'Moves::Descriptive',
      playbook_id: @chosen.id,
-     description: 'When your fate rears its ugly head, and
-  you act in accordance with any of your fate tags
-  (either heroic or doom) then mark experience. If it’s
-  a heroic tag, take +1 forward'
+     description: 'When your fate rears its ugly head, and '\
+     'you act in accordance with any of your fate tags '\
+     '(either heroic or doom) then mark experience. If it’s '\
+     'a heroic tag, take +1 forward'
    },
    {
      name: 'Invincible',
      type: 'Moves::Descriptive',
      playbook_id: @chosen.id,
-     description: 'You always count as having 2-armour.
-  This doesn’t stack with other protection.'
+     description: 'You always count as having 2-armour. '\
+     'This doesn’t stack with other protection.'
    },
    {
      name: 'Resilience',
      type: 'Moves::Descriptive',
      playbook_id: @chosen.id,
-     description: 'You heal faster than normal people. Any
-  time your harm gets healed, heal an extra point.
-  Additionally, your wounds count as 1-harm less for
-  the purpose of the Keeper’s harm moves.'
+     description: 'You heal faster than normal people. Any '\
+     'time your harm gets healed, heal an extra point. '\
+     'Additionally, your wounds count as 1-harm less for '\
+     'the purpose of the Keeper’s harm moves.'
    }].each do |move|
     Move.find_or_create_by!(move)
   end

--- a/db/seeds/playbooks/crooked.seeds.rb
+++ b/db/seeds/playbooks/crooked.seeds.rb
@@ -10,86 +10,87 @@ after :playbook do
     name: 'Hoodlum',
     type: 'Moves::Descriptive',
     playbook_id: @crooked.id,
-    description: 'You can use Tough instead of Charm to
-    manipulate someone with threats of violence'
+    description: 'You can use Tough instead of Charm to manipulate someone '\
+    'with threats of violence'
   },
    {
      name: 'Burglar',
      type: 'Moves::Rollable',
      playbook_id: @crooked.id,
-     description: 'When you break into a secure location, depending on your roll, you can pick some of the following:
-    - you get in undetected
-    - you get out undetected
-    - you don’t leave a mess
-    - you find what you were after',
+     description: "When you break into a secure location, depending on your "\
+     "roll, you can pick some of the following:\n"\
+     " • you get in undetected\n"\
+     " • you get out undetected\n"\
+     " • you don’t leave a mess\n"\
+     " • you find what you were after",
      rating: :sharp,
-     six_and_under: "On a miss, you are detected and don't gain entry, and you don't find what you are after.",
-     seven_to_nine: 'On a 7-9 you can choose 2 of the following:
-    - you get in undetected
-    - you get out undetected
-    - you don’t leave a mess
-    - you find what you were after',
-     ten_plus: 'On a 10+, you can choose 3 of the following:
-    - you get in undetected
-    - you get out undetected
-    - you don’t leave a mess
-    - you find what you were after'
+     six_and_under: "On a miss, you are detected and don't gain entry, and "\
+     "you don't find what you are after.",
+     seven_to_nine: "On a 7-9 you can choose 2 of the following:\n"\
+     " • you get in undetected\n"\
+     " • you get out undetected\n"\
+     " • you don’t leave a mess\n"\
+     " • you find what you were after",
+     ten_plus: "On a 10+, you can choose 3 of the following:\n"\
+     " • you get in undetected\n"\
+     " • you get out undetected\n"\
+     " • you don’t leave a mess\n"\
+     " • you find what you were after"
    },
    {
      name: 'Grifter',
      type: 'Moves::Descriptive',
      playbook_id: @crooked.id,
-     description: 'When you are about to manipulate
-    someone, you can ask the Keeper “What will convince this person to do
-    what I want?” The Keeper must answer honestly, but not necessarily completely.'
+     description: 'When you are about to manipulate someone, you can ask the '\
+     'Keeper “What will convince this person to do what I want?” The Keeper '\
+     'must answer honestly, but not necessarily completely.'
    },
    {
      name: 'Fixer',
      type: 'Moves::Rollable',
      playbook_id: @crooked.id,
-     description: 'If you need to buy something, sell something, or hire someone, roll +Charm.',
+     description: 'If you need to buy something, sell something, or hire '\
+     'someone, roll +Charm.',
      rating: :charm,
-     six_and_under: 'On a miss, the only person who can help is someone who
-      absolutely hates you.',
-     seven_to_nine: 'On a 7-9 you know the only person who can do it,
-      but there’s a complication.
-      Pick one: you owe them; they screwed you over; you screwed them over',
+     six_and_under: 'On a miss, the only person who can help is someone who '\
+     'absolutely hates you.',
+     seven_to_nine: 'On a 7-9 you know the only person who can do it, '\
+     'but there’s a complication. Pick one: you owe them; they screwed you '\
+     'over; you screwed them over',
      ten_plus: 'On a 10+ you know just the person who will be interested.'
    },
    {
      name: 'Assassin',
      type: 'Moves::Descriptive',
      playbook_id: @crooked.id,
-     description: 'When you take your first shot at an unsuspecting target,
-      do +2 Harm.'
+     description: 'When you take your first shot at an unsuspecting target, '\
+     'do +2 Harm.'
    },
    {
      name: 'Charlatan',
      type: 'Moves::Rollable',
      playbook_id: @crooked.id,
-     description: 'When you want people to think you are
-    using magic, roll +Cool. You may also manipulate people with
-    fortune telling. When you do that, ask “What are
-    they hoping for right now?” as a free question (even
-    on a miss).',
+     description: 'When you want people to think you are '\
+     'using magic, roll +Cool. You may also manipulate people with '\
+     'fortune telling. When you do that, ask “What are '\
+     'they hoping for right now?” as a free question (even '\
+     'on a miss).',
      rating: :cool,
      six_and_under: 'On a miss, you are not fooling anyone.',
-     seven_to_nine: 'On a 7-9, you tripped up a couple of times,
-      maybe someone will notice.',
+     seven_to_nine: 'On a 7-9, you tripped up a couple of times, '\
+     'maybe someone will notice.',
      ten_plus: 'Your audience is amazed and fooled by your illusion.'
    },
    {
      name: 'Pickpocket',
      type: 'Moves::Rollable',
      playbook_id: @crooked.id,
-     description: 'When you steal something small, roll
-    +Charm.',
+     description: 'When you steal something small, roll +Charm.',
      rating: :charm,
      six_and_under: 'On a miss, you are caught pickpocketing.',
-     seven_to_nine: 'On a 7-9 either you don’t grab it,
-      you grab the wrong thing, or they remember you later: your choice.',
-     ten_plus: 'On a 10 or more, you get it
-      and they didn’t notice you taking it.'
+     seven_to_nine: 'On a 7-9 either you don’t grab it, '\
+     'you grab the wrong thing, or they remember you later: your choice.',
+     ten_plus: 'On a 10 or more, you get it and they didn’t notice you taking it.'
    }].each do |move|
     Move.find_or_create_by!(move)
   end
@@ -102,92 +103,91 @@ after :playbook do
       name: 'Artifact',
       type: 'Moves::Descriptive',
       playbook_id: @crooked.id,
-      description: 'You ‘found’ a magical artifact with handy
-        powers, and kept it. Pick one: Protective amulet
-        (1-armour magic recharge), Lucky charm (may be
-        used as a Luck point, once only), Grimoire (studying
-        the book gives +1 forward to use magic), Skeleton
-        key (opens any magically sealed lock), Imp stone (A
-        weak demon is bound to serve the holder. The imp
-        must be summoned with the use magic move).'
+      description: 'You ‘found’ a magical artifact with handy '\
+      'powers, and kept it. Pick one: Protective amulet '\
+      '(1-armour magic recharge), Lucky charm (may be '\
+      'used as a Luck point, once only), Grimoire (studying '\
+      'the book gives +1 forward to use magic), Skeleton '\
+      'key (opens any magically sealed lock), Imp stone (A '\
+      'weak demon is bound to serve the holder. The imp '\
+      'must be summoned with the use magic move).'
     },
     {
       name: 'Crew', # TEAM RULES
       type: 'Moves::Descriptive',
       playbook_id: @crooked.id,
-      description: 'You have a regular crew, a team of three or
-      four people who will help you out with pretty much
-      anything. They count as a team.'
+      description: 'You have a regular crew, a team of three or '\
+      'four people who will help you out with pretty much '\
+      'anything. They count as a team.'
     },
     {
       name: 'Deal with the Devil',
       type: 'Moves::Descriptive',
       playbook_id: @crooked.id,
-      description: 'You sold your soul to the Devil.
-      Pick one or two things you got out of the deal: wealth,
-      fame, youth, sensual gratification, skill (add +1 to
-      two ratings). Payment is due either when you die, in
-      six months (if you picked two things) or otherwise
-      in a year'
+      description: 'You sold your soul to the Devil. '\
+      'Pick one or two things you got out of the deal: wealth, '\
+      'fame, youth, sensual gratification, skill (add +1 to '\
+      'two ratings). Payment is due either when you die, in '\
+      'six months (if you picked two things) or otherwise '\
+      'in a year'
     },
     {
       name: 'Friends on the Force',
       type: 'Moves::Rollable',
       playbook_id: @crooked.id,
-      description: 'You know a few cops who
-      can be persuaded to look the other way, or do you
-      a favour, for certain considerations. You can act
-      under pressure to get in touch with them when you
-      need to divert any law enforcement attention. There
-      will be a cost, although maybe not right now.',
+      description: 'You know a few cops who '\
+      'can be persuaded to look the other way, or do you '\
+      'a favour, for certain considerations. You can act '\
+      'under pressure to get in touch with them when you '\
+      'need to divert any law enforcement attention. There '\
+      'will be a cost, although maybe not right now.',
       rating: :cool,
       six_and_under: "They're not answering your calls.",
       seven_to_nine: "There's a worse outcome, hard choice, or price to pay.",
-      ten_plus: "They're willing to look the other way,
-        but there'll be a price."
+      ten_plus: "They're willing to look the other way, but there'll be a price."
     },
     {
       name: 'Made',
       type: 'Moves::Descriptive',
       playbook_id: @crooked.id,
-      description: 'You’re “made” in a gang. Name the gang and
-      describe how their operations tie into your background.
-      You can call on gang members to help you
-      out, but they’ll expect to be paid. Your bosses will
-      have requests for you now and again, but you’ll be
-      paid. Minor trouble will be overlooked, but you
-      better not screw over any other made gangsters.'
+      description: 'You’re “made” in a gang. Name the gang and '\
+      'describe how their operations tie into your background. '\
+      'You can call on gang members to help you '\
+      'out, but they’ll expect to be paid. Your bosses will '\
+      'have requests for you now and again, but you’ll be '\
+      'paid. Minor trouble will be overlooked, but you '\
+      'better not screw over any other made gangsters.'
     },
     {
       name: 'Driver',
       type: 'Moves::Descriptive',
       playbook_id: @crooked.id,
-      description: ' You have +1 ongoing while driving, plus you
-      can hotwire anything (the older it is, the fewer tools
-      you need to do it). You also own two handy, widely-available
-      vehicles (perhaps a sportscar and a van).'
+      description: 'You have +1 ongoing while driving, plus you '\
+      'can hotwire anything (the older it is, the fewer tools '\
+      'you need to do it). You also own two handy, widely-available '\
+      'vehicles (perhaps a sportscar and a van).'
     },
     {
       name: 'Home Ground',
       type: 'Moves::Descriptive',
       playbook_id: @crooked.id,
-      description: "Your crew made a point of keeping
-      the locals happy - keeping them safe, ensuring things
-      always went down okay. When you’re back in your
-      old neighbourhood, you can always find people who
-      will hide you or help you with a minor favour, no
-      questions asked."
+      description: "Your crew made a point of keeping "\
+      "the locals happy — keeping them safe, ensuring things "\
+      "always went down okay. When you’re back in your "\
+      "old neighbourhood, you can always find people who "\
+      "will hide you or help you with a minor favour, no "\
+      "questions asked."
     },
     {
       name: 'Notorious',
       type: 'Moves::Descriptive',
       playbook_id: @crooked.id,
-      description: 'You have a reputation from your criminal past.
-      When you reveal who you are, your
-      terrifying reputation counts as a reason for people
-      to do what you ask, for the manipulate someone
-      move. Revealing your identity to someone can create
-      other problems later, of course.'
+      description: 'You have a reputation from your criminal past. '\
+      'When you reveal who you are, your '\
+      'terrifying reputation counts as a reason for people '\
+      'to do what you ask, for the manipulate someone '\
+      'move. Revealing your identity to someone can create '\
+      'other problems later, of course.'
     }
   ].each do |move|
     Move.find_or_create_by!(move)

--- a/db/seeds/playbooks/divine.seeds.rb
+++ b/db/seeds/playbooks/divine.seeds.rb
@@ -9,79 +9,79 @@ after :playbook do
       type: 'Moves::Rollable',
       rating: :weird,
       description: 'At the beginning of each mystery, roll +Weird.',
-      ten_plus: "On a 10+, your Superiors ask \
-      you to do something simple, and  you get to ask them \
-      one of the questions from the investigate a mystery \
-      move right now.",
-      seven_to_nine: "On a 7-9, they ask you
-      to do something complicated or difficult, but you get \
-      to ask them one of the questions from the investigate a \
-      mystery move right now.",
-      six_and_under: "On a miss, you are required to do something terrible. \
-      If you do not accomplish what they’ve ordered, you cannot use this move \
-      again until you have made up for your failure."
+      ten_plus: "On a 10+, your Superiors ask "\
+      "you to do something simple, and  you get to ask them "\
+      "one of the questions from the investigate a mystery "\
+      "move right now.",
+      seven_to_nine: "On a 7-9, they ask you "\
+      "to do something complicated or difficult, but you get "\
+      "to ask them one of the questions from the investigate a "\
+      "mystery move right now.",
+      six_and_under: "On a miss, you are required to do something terrible. "\
+      "If you do not accomplish what they’ve ordered, you cannot use this move "\
+      "again until you have made up for your failure."
     },
     {
       name: 'Angel Wings',
       type: 'Moves::Rollable',
       rating: :weird,
-      description: "You can go instantly to anywhere you’ve \
-      visited before, or to a person you know well. \
-      When you carry one or two people with you, roll +Weird.",
+      description: "You can go instantly to anywhere you’ve "\
+      "visited before, or to a person you know well. "\
+      "When you carry one or two people with you, roll +Weird.",
       ten_plus: 'On a 10+ you all go where you wanted.',
-      seven_to_nine: "On a 7-9, you don’t quite manage it. \
-      Either you are all separated, or you all appear in the \
-      wrong place.",
-      six_and_under: "On less than a 6, you're all separated \
-      and in the wrong places."
+      seven_to_nine: "On a 7-9, you don’t quite manage it. "\
+      "Either you are all separated, or you all appear in the "\
+      "wrong place.",
+      six_and_under: "On less than a 6, you're all separated "\
+      "and in the wrong places."
     },
     {
       name: 'What I Need, When I Need It',
       type: 'Moves::Descriptive',
-      description: "You may store any small object you own, \
-      putting it into a magical space nobody can get to. \
-      You may retrieve anything you stored at any time; \
-      it appears in your hand."
+      description: "You may store any small object you own, "\
+      "putting it into a magical space nobody can get to. "\
+      "You may retrieve anything you stored at any time; "\
+      "it appears in your hand."
     },
     {
       name: 'Smite',
       type: 'Moves::Descriptive',
-      description: "Your body and divine weapon always count \
-      as a weakness against the monsters you fight. \
-      Your unarmed attacks are 2-harm intimate hand messy."
+      description: "Your body and divine weapon always count "\
+      "as a weakness against the monsters you fight. "\
+      "Your unarmed attacks are 2-harm intimate hand messy."
     },
     {
       name: 'Soothe',
       type: 'Moves::Descriptive',
-      description: "When you talk to someone for a few \
-        seconds in a quiet voice, you can calm them down, \
-        blocking any panic, anger, or other negative emotions \
-        they have. This works even if the thing that freaked \
-        them out is still present, as long as your voice can be heard."
+      description: "When you talk to someone for a few "\
+      "seconds in a quiet voice, you can calm them down, "\
+      "blocking any panic, anger, or other negative emotions "\
+      "they have. This works even if the thing that freaked "\
+      "them out is still present, as long as your voice can be heard."
     },
     {
       name: 'Lay on Hands',
-      description: "Your touch can heal injury and disease. \
-      When you lay your hands on someone hurt, roll +Cool.",
+      description: "Your touch can heal injury and disease. "\
+      "When you lay your hands on someone hurt, roll +Cool.",
       type: 'Moves::Rollable',
       rating: :cool,
       ten_plus: 'On a 10+, heal 2 harm or an illness, plus they’re stabilized.',
-      seven_to_nine: "On a 7-9, you can heal 2 harm or an illness, \
-      and stabilize them, but you take the harm or illness into yourself.",
+      seven_to_nine: "On a 7-9, you can heal 2 harm or an illness, "\
+      "and stabilize them, but you take the harm or illness into yourself.",
       six_and_under: 'On a miss, your aura causes them extra harm.'
     },
     {
       name: 'Cast Out Evil',
-      description: "You may banish an unnatural creature from your presence. \
-      Roll +Tough.",
+      description: "You may banish an unnatural creature from your presence. "\
+      "Roll +Tough.",
       type: 'Moves::Rollable',
       rating: :tough,
-      ten_plus: "On a 10+ it is banished. The banished creature is unharmed, \
-      and you have no control over where it goes.",
-      seven_to_nine: "On a 7-9 it takes a little while \
-        for the banishing to take effect—the creature \
-        has time to make one or two actions. The banished creature \
-        is unharmed, and you have no control over where it goes.",
+      ten_plus: "On a 10+ it is banished. The banished creature is unharmed, "\
+      "and you have no control over where it goes.",
+      seven_to_nine: "On a 7-9 it takes a little while "\
+      "for the banishing to take effect—the creature "\
+      "has time to make one or two actions. The banished creature "\
+      "is unharmed, and you have no control over where it goes.",
       six_and_under: 'On a miss, something is keeping it here. That’s bad.'
     }
   ].each do |move|

--- a/db/seeds/playbooks/flake.seeds.rb
+++ b/db/seeds/playbooks/flake.seeds.rb
@@ -11,16 +11,16 @@ after :playbook do
       name: 'Connect the Dots',
       type: 'Moves::Rollable',
       rating: :sharp,
-      description: ' At the beginning of each mystery,
-      if you look for the wider patterns that current
-      events might be part of, roll +Sharp. Spend your hold during the
-      mystery to ask the Keeper any one of the following
-      questions:
-      - Is this person connected to current events more than they are saying?
-      - When and where will the next critical event occur?
-      - What does the monster want from this person?
-      - Is this connected to previous mysteries we have investigated?
-      - How does this mystery connect to the bigger picture?',
+      description: "At the beginning of each mystery, "\
+      "if you look for the wider patterns that current "\
+      "events might be part of, roll +Sharp. Spend your hold during the "\
+      "mystery to ask the Keeper any one of the following "\
+      "questions:\n"\
+      " • Is this person connected to current events more than they are saying?\n"\
+      " • When and where will the next critical event occur?\n"\
+      " • What does the monster want from this person?\n"\
+      " • Is this connected to previous mysteries we have investigated?\n"\
+      " • How does this mystery connect to the bigger picture?",
       six_and_under: 'On a miss hold 0',
       seven_to_nine: 'On a 7-9 hold 1',
       ten_plus: 'On a 10+ hold 3'
@@ -46,34 +46,35 @@ after :playbook do
       rating: :weird,
       description: 'When you act all crazy to avoid something, roll +Weird.',
       six_and_under: 'On a miss, you draw lots (but not all) of the attention.',
-      seven_to_nine: 'On a 7-9, pick one:
-      - unthreatening
-      - unimportant',
+      seven_to_nine: "On a 7-9, pick one:\n"\
+      " • unthreatening\n"\
+      " • unimportant",
       ten_plus: 'On a 10+ you’re regarded as unthreatening and unimportant.'
     },
     {
       name: 'Contrary',
       type: 'Moves::Descriptive',
-      description: 'When you seek out and receive someone’s honest advice on the best course of action for
-      you and then do something else instead, mark experience. If you do exactly the opposite of their advice,
-      you also take +1 ongoing on any moves you make
-      pursuing that course.'
+      description: 'When you seek out and receive someone’s honest advice on '\
+      'the best course of action for '\
+      'you and then do something else instead, mark experience. If you do '\
+      'exactly the opposite of their advice, you also take +1 ongoing on any '\
+      'moves you make pursuing that course.'
     },
     {
       name: 'Net Friends',
       type: 'Moves::Rollable',
       rating: :charm,
-      description: 'You know a lot of people on the Internet. When you contact a net friend to help you with
-      a mystery, roll +Charm.',
+      description: 'You know a lot of people on the Internet. When you '\
+      'contact a net friend to help you with a mystery, roll +Charm.',
       six_and_under: 'On a miss, you burn some bridges.',
-      seven_to_nine: 'On a 7-9, they’re prepared to help, but it’s either
-      going to take some time or you’re going to have to do
-      part of it yourself.',
-      ten_plus: ' On a 10+, they’re available and helpful:
-      - they can fix something
-      - break a code
-      - hack a computer
-      - get you some special information'
+      seven_to_nine: 'On a 7-9, they’re prepared to help, but it’s either '\
+      'going to take some time or you’re going to have to do '\
+      'part of it yourself.',
+      ten_plus: "On a 10+, they’re available and helpful:\n"\
+      " • they can fix something\n"\
+      " • break a code\n"\
+      " • hack a computer\n"\
+      " • get you some special information"
     },
     {
       name: 'Sneaky',

--- a/db/seeds/playbooks/monstrous.seeds.rb
+++ b/db/seeds/playbooks/monstrous.seeds.rb
@@ -11,58 +11,50 @@ after :playbook do
       name: 'Immortal',
       type: 'Moves::Descriptive',
       playbook_id: @monstrous.id,
-      description:'You do not age or sicken, and whenever
-        you suffer harm you suffer 1-harm less.'
+      description:'You do not age or sicken, and whenever '\
+      'you suffer harm you suffer 1-harm less.'
     },
     {
       name: 'Unnatural Appeal',
       type: 'Moves::Descriptive',
       playbook_id: @monstrous.id,
-      description: 'Roll +Weird instead of +Charm
-        when you manipulate someone.'
+      description: 'Roll +Weird instead of +Charm when you manipulate someone.'
     },
     {
       name: 'Unholy Strength',
       type: 'Moves::Descriptive',
       playbook_id: @monstrous.id,
-      description: 'Roll +Weird instead of +Tough
-        when you kick some ass.'
+      description: 'Roll +Weird instead of +Tough when you kick some ass.'
     },
     {
       name: 'Incorporeal',
       type: 'Moves::Descriptive',
       playbook_id: @monstrous.id,
-      description: 'You may move freely through solid
-        objects (but not people).'
+      description: 'You may move freely through solid objects (but not people).'
     },
     {
       name: 'Preternatural Speed',
       type: 'Moves::Descriptive',
       playbook_id: @monstrous.id,
-      description: 'You go much faster than
-        normal people. When you chase, flee, or run take
-        +1 ongoing.'
+      description: 'You go much faster than normal people. When you chase, '\
+      'flee, or run take +1 ongoing.'
     },
     {
       name: 'Claws of the Beast',
       type: 'Moves::Descriptive',
       playbook_id: @monstrous.id,
-      description: 'All your natural attacks get +1
-        harm.'
+      description: 'All your natural attacks get +1 harm.'
     },
     {
       name: 'Mental Dominion',
       type: 'Moves::Rollable',
       playbook_id: @monstrous.id,
-      description: 'When you gaze into a normal
-        human’s eyes and exert your will over them, roll
-        +Charm. You may spend your hold to give them an order.
-        Regular people will follow your order, whatever it is. 
-        Hunters can choose whether they do it or not. If they do, 
-        they mark experience.',
+      description: 'When you gaze into a normal human’s eyes and exert your '\
+      'will over them, roll +Charm. You may spend your hold to give them an '\
+      'order. Regular people will follow your order, whatever it is. Hunters '\
+      'can choose whether they do it or not. If they do, they mark experience.',
       rating: :charm,
-      six_and_under: 'It is clear that you hold no control
-        over them.',
+      six_and_under: 'It is clear that you hold no control over them.',
       seven_to_nine: 'Hold 1.',
       ten_plus: 'Hold 3.'
     },
@@ -70,8 +62,7 @@ after :playbook do
       name: 'Unquenchable Vitality',
       type: 'Moves::Rollable',
       playbook_id: @monstrous.id,
-      description: 'When you have taken harm,
-        you can heal yourself. Roll +Cool.',
+      description: 'When you have taken harm, you can heal yourself. Roll +Cool.',
       rating: :cool,
       six_and_under: 'Your injuries worsen.',
       seven_to_nine: 'Heal 1-harm and stabilise your injuries.',
@@ -81,9 +72,8 @@ after :playbook do
       name: 'Dark Negotiator',
       type: 'Moves::Descriptive',
       playbook_id: @monstrous.id,
-      description: 'You can use the manipulate
-        someone move on monsters as well as people, if
-        they can reason and talk.'
+      description: 'You can use the manipulate someone move on monsters as '\
+      'well as people, if they can reason and talk.'
     },
     {
       name: 'Flight',
@@ -95,19 +85,17 @@ after :playbook do
       name: 'Shapeshifter',
       type: 'Moves::Descriptive',
       playbook_id: @monstrous.id,
-      description: 'You may change your form (usually
-        into an animal). Decide if you have just one alternate 
-        form or several, and detail them. You gain +1
-        to investigate a mystery when using an alternate
-        form’s superior senses (e.g. smell for a wolf, sight for
-        an eagle).'
+      description: 'You may change your form (usually into an animal). Decide '\
+      'if you have just one alternate form or several, and detail them. You '\
+      'gain +1 to investigate a mystery when using an alternate form’s '\
+      'superior senses (e.g. smell for a wolf, sight for an eagle).'
     },
     {
       name: 'Something Borrowed',
       type: 'Moves::Descriptive',
       playbook_id: @monstrous.id,
-      description: 'Take a move from a hunter
-        playbook that is not currently in play.'
+      description: 'Take a move from a hunter '\
+      'playbook that is not currently in play.'
     }
   ].each do |move|
     Move.find_or_create_by!(move)
@@ -202,14 +190,14 @@ after :playbook do
     },
     {
       type: 'Improvements::AdvancedMove',
-      description: 'Free yourself from the curse of your kind. Your curse
-        no longer applies, but you lose 1 Weird.',
+      description: 'Free yourself from the curse of your kind. Your curse '\
+      'no longer applies, but you lose 1 Weird.',
       advanced: true
     },
     {
       type: 'Improvements::Retire',
-      description: 'You turn evil (again). Retire this character, they
-      become one of the Keeper’s threats.',
+      description: 'You turn evil (again). Retire this character, they '\
+      'become one of the Keeper’s threats.',
       advanced: true
     },
     {

--- a/db/seeds/playbooks/professional.seeds.rb
+++ b/db/seeds/playbooks/professional.seeds.rb
@@ -12,11 +12,11 @@ after :playbook do
       name: 'Bottle It Up',
       type: 'Moves::Descriptive',
       playbook_id: @professional.id,
-      description: 'If you want, you can take up to +3
-      bonus when you act under pressure. For each +1
-      you use, the Keeper holds 1. That hold can be spent
-      later—one for one—to give you -1 on any move
-      except act under pressure.'
+      description: 'If you want, you can take up to +3 '\
+      'bonus when you act under pressure. For each +1 '\
+      'you use, the Keeper holds 1. That hold can be spent '\
+      'later—one for one—to give you -1 on any move '\
+      'except act under pressure.'
     },
     {
       name: 'Unfazeable',
@@ -28,70 +28,69 @@ after :playbook do
       name: 'Battlefield Awareness',
       type: 'Moves::Descriptive',
       playbook_id: @professional.id,
-      description: 'You always know what’s
-      happening around you, and what to watch out for.
-      Take +1 armour (max 2-armour) on top of whatever
-      you get from your gear.'
+      description: 'You always know what’s '\
+      'happening around you, and what to watch out for. '\
+      'Take +1 armour (max 2-armour) on top of whatever '\
+      'you get from your gear.'
     },
     {
       name: 'Leave No One Behind',
       rating: :sharp,
-      six_and_under: 'On a miss, you fail to
-      get them out and you’ve attracted hostile attention.',
-      seven_to_nine: 'You can either get them out
-      or suffer no harm, you choose.',
-      ten_plus: 'You get
-      them out clean.',
+      six_and_under: 'On a miss, you fail to '\
+      'get them out and you’ve attracted hostile attention.',
+      seven_to_nine: 'You can either get them out '\
+      'or suffer no harm, you choose.',
+      ten_plus: 'You get them out clean.',
       type: 'Moves::Rollable',
       playbook_id: @professional.id,
-      description: 'In combat, when you help
-      someone escape, roll +Sharp.'
+      description: 'In combat, when you help '\
+      'someone escape, roll +Sharp.'
     },
     {
       name: 'Tactical Genius',
       type: 'Moves::Descriptive',
       playbook_id: @professional.id,
-      description: 'When you read a bad situation,
-      you may roll +Cool instead of +Sharp.'
+      description: 'When you read a bad situation, '\
+      'you may roll +Cool instead of +Sharp.'
     },
     {
       name: 'Medic',
       rating: :cool,
       six_and_under: 'You cause an extra 1 harm.',
       seven_to_nine: 'Choose one: heal 2 harm or stabilize the injury.',
-      ten_plus: 'The patient is stabilized and healed of 2
-      harm',
+      ten_plus: 'The patient is stabilized and healed of 2 harm',
       type: 'Moves::Rollable',
       playbook_id: @professional.id,
-      description: 'You have a full first aid kit, and the training
-      to heal people. When you do first aid, roll +Cool.'
+      description: 'You have a full first aid kit, and the training '\
+      'to heal people. When you do first aid, roll +Cool.'
     },
     {
       name: 'Mobility',
       type: 'Moves::Descriptive',
       playbook_id: @professional.id,
-      description: 'You have a truck, van, or car built for \      monster hunting. Choose two good things and one
-      bad thing about it. \
-      Good things: roomy; surveillance gear; fast; \
-      stealthy; intimidating; classic; medical kit; sleeping space; toolkit; concealed weapons; anonymous;
-      armoured (+1 armour inside); tough; monster cage.
-      Bad things: loud; obvious; temperamental; beaten-up; gas-guzzler; uncomfortable; slow; old.'
+      description: 'You have a truck, van, or car built for '\
+      'monster hunting. Choose two good things and one '\
+      'bad thing about it. '\
+      'Good things: roomy; surveillance gear; fast; '\
+      'stealthy; intimidating; classic; medical kit; sleeping space; toolkit; concealed weapons; anonymous; '\
+      'armoured (+1 armour inside); tough; monster cage. '\
+      'Bad things: loud; obvious; temperamental; beaten-up; gas-guzzler; uncomfortable; slow; old.'\
     },
     {
       name: 'Deal with the Agency',
       rating: :cool,
-      six_and_under: 'You screwed
-      up: you might be suspended or under investigation,
-      or just in the doghouse. You certainly aren’t going to
-      get any help until you sort it all out.',
-      seven_to_nine: 'Things aren’t so great. You might get chewed out
-      by your superiors and there’ll be fallout, but you get
-      what you need for the job.',
+      six_and_under: 'You screwed '\
+      'up: you might be suspended or under investigation, '\
+      'or just in the doghouse. You certainly aren’t going to '\
+      'get any help until you sort it all out.',
+      seven_to_nine: 'Things aren’t so great. You might get chewed out '\
+      'by your superiors and there’ll be fallout, but you get '\
+      'what you need for the job.',
       ten_plus: ' you’re good—your request for gear or personnel is okayed, or your slip-up goes unnoticed',
       type: 'Moves::Rollable',
       playbook_id: @professional.id,
-      description: 'When you deal with the Agency, requesting help or
-      gear, or making excuses for a failure, roll +Sharp.'
+      description: 'When you deal with the Agency, requesting help or '\
+      'gear, or making excuses for a failure, roll +Sharp.'
     }
   ].each do |move|
     Move.find_or_create_by!(move)
@@ -195,9 +194,9 @@ after :playbook do
       advanced: true
     },
     {
-      description: 'Get some or all of the other players’ hunters hired
-      by your agency. They get the deal with the agency
-      move, as well as salary and benefits.',
+      description: 'Get some or all of the other players’ hunters hired '\
+      'by your agency. They get the deal with the agency '\
+      'move, as well as salary and benefits.',
       playbook: @professional,
       advanced: true
     }

--- a/db/seeds/playbooks/spell_slinger.seeds.rb
+++ b/db/seeds/playbooks/spell_slinger.seeds.rb
@@ -32,10 +32,10 @@ after :playbook do
     playbook_id: @spell_slinger.id,
     description: "When you miss a use magic "\
     "roll you can choose one of the following options "\
-    "instead of losing control of the magi\n"\
+    "instead of losing control of the magic:\n"\
     " • Fizzle: The preparations and materials for the "\
     "spell are ruined. You’ll have to start over from "\
-    "scratch with the prep time double\n"\
+    "scratch with the prep time doubled.\n"\
     " • This Is Gonna Suck: The effect happens, but "\
     "you trigger all of the listed glitches but one. You "\
     "pick the one you avoid."

--- a/db/seeds/playbooks/spell_slinger.seeds.rb
+++ b/db/seeds/playbooks/spell_slinger.seeds.rb
@@ -10,92 +10,93 @@ after :playbook do
     name: "Advanced Arcane Training",
     type: 'Moves::Descriptive',
     playbook_id: @spell_slinger.id,
-    description: "If you have two of your \
-      three Tools and Techniques at the ready, you may \
-      ignore the third one."
+    description: "If you have two of your "\
+    "three Tools and Techniques at the ready, you may "\
+    "ignore the third one."
   },
   {
     name: "Arcane Reputation",
     type: 'Moves::Descriptive',
     playbook_id: @spell_slinger.id,
-    description: "Pick three big organizations or \
-      groups in the supernatural community, which can \
-      include some of the more sociable types of monsters. \
-      They’ve heard of you and respect your power. With \
-      affected humans, take +1 forward when you manipulate them. You may manipulate affected monsters \
-      as if they were human, with no bonus."
+    description: "Pick three big organizations or "\
+    "groups in the supernatural community, which can "\
+    "include some of the more sociable types of monsters. "\
+    "They’ve heard of you and respect your power. With "\
+    "affected humans, take +1 forward when you manipulate "\
+    "them. You may manipulate affected monsters "\
+    "as if they were human, with no bonus."
   },
   {
     name: 'Could’ve Been Worse',
     type: 'Moves::Descriptive',
     playbook_id: @spell_slinger.id,
-    description: "When you miss a use magic  \
-      roll you can choose one of the following options \
-      instead of losing control of the magic:
-      \n - Fizzle: The preparations and materials for the \
-      spell are ruined. You’ll have to start over from \
-      scratch with the prep time doubled.
-      \n - This Is Gonna Suck: The effect happens, but \
-      you trigger all of the listed glitches but one. You \
-      pick the one you avoid."
+    description: "When you miss a use magic "\
+    "roll you can choose one of the following options "\
+    "instead of losing control of the magi\n"\
+    " • Fizzle: The preparations and materials for the "\
+    "spell are ruined. You’ll have to start over from "\
+    "scratch with the prep time double\n"\
+    " • This Is Gonna Suck: The effect happens, but "\
+    "you trigger all of the listed glitches but one. You "\
+    "pick the one you avoid."
   },
   {
     name: 'Enchanted Clothing',
     type: 'Moves::Descriptive',
     playbook_id: @spell_slinger.id,
-    description: "Pick an article of every-day \
-      clothing–it’s enchanted without any change in \
-      appearance. Take -1 harm from any source that tries \
-      to get at you through the garment."
+    description: "Pick an article of every-day "\
+    "clothing–it’s enchanted without any change in "\
+    "appearance. Take -1 harm from any source that tries "\
+    "to get at you through the garment."
   },
   {
     name: 'Forensic Divination',
     type: 'Moves::Descriptive',
     playbook_id: @spell_slinger.id,
-    description: "When you successfully investigate a mystery, you may ask 'What magic was \
-      done here?' as a free extra question."
+    description: "When you successfully investigate a mystery, you may ask "\
+    "'What magic was done here?' as a free extra question."
   },
   {
     name: 'Go Big or Go Home',
     type: 'Moves::Descriptive',
     playbook_id: @spell_slinger.id,
-    description: "When you must use magic \
-      as a requirement for Big Magic, take +1 ongoing to \
-      those use magic rolls."
+    description: "When you must use magic as a requirement for Big Magic, "\
+    "take +1 ongoing to those use magic rolls."
   },
   {
     name: 'Not My Fault',
     type: 'Moves::Descriptive',
     playbook_id: @spell_slinger.id,
-    description: "+1 to act under pressure when you \
-      are dealing with the consequences of your own spellcasting."
+    description: "+1 to act under pressure when you "\
+    "are dealing with the consequences of your own spellcasting."
   },
   {
     name: 'Practitioner',
     type: 'Moves::Descriptive',
     playbook_id: @spell_slinger.id,
-    description: "Choose two effects available to you \
-      under use magic. Take +1 to use magic whenever \
-      you choose one of those effects."
+    description: "Choose two effects available to you "\
+    "under use magic. Take +1 to use magic whenever "\
+    "you choose one of those effects."
   },
   {
     name: 'Shield Spell',
     type: 'Moves::Descriptive',
     playbook_id: @spell_slinger.id,
-    description: "When you protect someone, gain \
-      2-armour against any harm that is transferred to you. \
-      This doesn’t stack with your other armour, if any."
+    description: "When you protect someone, gain "\
+    "2-armour against any harm that is transferred to you. "\
+    "This doesn’t stack with your other armour, if any."
   },
   {
     name: 'Third Eye',
     type: 'Moves::Descriptive',
     playbook_id: @spell_slinger.id,
-    description: "When you read a bad situation, you can \
-    open up your third eye for a moment to take in \
-    extra information. Take +1 hold on any result of 7 \ 
-    or more, plus you can see invisible things. On a miss, \
-    you may still get 1 hold, but you’re exposed to supernatural danger. Unfiltered hidden reality is rough on \
-    the mind!" 
+    description: "When you read a bad situation, you can "\
+    "open up your third eye for a moment to take in "\
+    "extra information. Take +1 hold on any result of 7 or "\
+    "more, plus you can see invisible things. On a miss, "\
+    "you may still get 1 hold, but you’re exposed to "\
+    "supernatural danger. Unfiltered hidden reality is rough on "\
+    "the mind!"
   }].each do |move|
     m = Move.find_or_initialize_by(name: move[:name], playbook_id: move[:playbook_id])
     m.update!(move)

--- a/db/seeds/playbooks/wronged.seeds.rb
+++ b/db/seeds/playbooks/wronged.seeds.rb
@@ -11,77 +11,75 @@ after :playbook do
     name: "I Know My Prey",
     type: 'Moves::Descriptive',
     playbook_id: @wronged.id,
-    description: 'You get +1 ongoing when knowingly investigating, pursuing or fighting the breed of
-monster that caused your loss.'
+    description: 'You get +1 ongoing when knowingly investigating, pursuing '\
+    'or fighting the breed of monster that caused your loss.'
   },
    {
      name: 'Berserk',
      type: 'Moves::Descriptive',
      playbook_id: @wronged.id,
-     description: 'No matter how much harm you take, you
-can always keep going until the current fight is over.
-During a fight, the Keeper may not use harm moves
-on you and you cannot die. When the fight ends, all
-harm takes effect as normal'
+     description: 'No matter how much harm you take, you '\
+     'can always keep going until the current fight is over. '\
+     'During a fight, the Keeper may not use harm moves '\
+     'on you and you cannot die. When the fight ends, all '\
+     'harm takes effect as normal'
    },
    {
      name: 'NEVER AGAIN',
      type: 'Moves::Descriptive',
      playbook_id: @wronged.id,
-     description: 'In combat, you may choose to
-*protect someone* without rolling, as if you had
-rolled a 10+, but you may not choose to "suffer little
-harm."'
+     description: 'In combat, you may choose to '\
+     '*protect someone* without rolling, as if you had '\
+     'rolled a 10+, but you may not choose to "suffer little '\
+     'harm."'
    },
    {
      name: 'What Does Not Kill Me...',
      type: 'Moves::Descriptive',
      playbook_id: @wronged.id,
-     description: ' If you have suffered harm
-in a fight, you gain +1 ongoing until the fight is over.'
+     description: 'If you have suffered harm '\
+     'in a fight, you gain +1 ongoing until the fight is over.'
    },
    {
      name: 'Fervor',
      type: 'Moves::Descriptive',
      playbook_id: @wronged.id,
-     description: 'When you *manipulate someone*, roll
-+Tough instead of +Charm.'
+     description: 'When you *manipulate someone*, roll '\
+     '+Tough instead of +Charm.'
    },
    {
      name: 'Safety First',
      type: 'Moves::Descriptive',
      playbook_id: @wronged.id,
-     description: 'You have jury-rigged extra protection
-into your gear, giving you +1 armour (maximum
-2-armour).'
+     description: 'You have jury-rigged extra protection '\
+     'into your gear, giving you +1 armour (maximum '\
+     '2-armour).'
    },
    {
      name: 'DIY Surgery',
      rating: :cool,
-     ten_plus: 'On a 10+ it’s all good, it counts as normal first aid,
-plus stabilize the injury and heal 1 harm.',
-     seven_to_nine: 'On a 7-9
-it counts as normal first aid, plus one of these, your
-choice:
-• Stabilise the injury but the patient takes -1
-forward.
-• Heal 1-harm and stabilise for now, but it will
-return as 2-harm and become unstable again
-later.
-• Heal 1-harm and stabilise but the patient takes
--1 ongoing until it’s fixed properly',
-     six_and_under: 'No heroic measures undertaken; no impact on the efficacy of your first aid',
+     ten_plus: 'On a 10+ it’s all good, it counts as normal first aid, '\
+     'plus stabilize the injury and heal 1 harm.',
+     seven_to_nine: "On a 7-9 it counts as normal first aid, plus one of "\
+     "these, your choice:\n"\
+     " • Stabilise the injury but the patient takes -1 forward.\n"\
+     " • Heal 1-harm and stabilise for now, but it will return as 2-harm and "\
+         "become unstable again later.\n"\
+     " • Heal 1-harm and stabilise but the patient takes -1 ongoing until "\
+         "it’s fixed properly\n",
+     six_and_under: "No heroic measures undertaken; no impact on the "\
+     "efficacy of your first aid",
      type: 'Moves::Rollable',
      playbook_id: @wronged.id,
-     description: 'When you do *quick and dirty first
-aid on someone* (including yourself), roll +Cool.'
+     description: "When you do *quick and dirty first aid on someone* "\
+     "(including yourself), roll +Cool."
    },
    {
        name: 'Tools Matter',
        type: 'Moves::Descriptive',
        playbook_id: @wronged.id,
-       description: 'With your signature weapon (see
-your gear, below), you get +1 to *kick some ass*.'
+       description: "With your signature weapon (see your gear, below), you "\
+       "get +1 to *kick some ass*."
    }].each do |move|
     Move.find_or_create_by!(move)
   end


### PR DESCRIPTION
## Description of Feature or Issue
closes #232
:speech_balloon: :seedling:

• Fix some multiline strings including the indentation whitespace
• Remove newlines where they are not supposed to be
• Make bullet points for list items consistently '•'
• Make the whitespace around list items consistent

## User-Facing Changes
Lists in moves now consistently contain '•' as bulletpoints