### PR TITLE
Reduce number of CSP + Turbolinks complaints

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,15 +1,16 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Hunterskeepers</title>
+    <title>HuntersKeepers</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
     <meta charset="utf-8">
+    <meta name="turbolinks-cache-control" content="no-cache">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
     <link rel="stylesheet" href="https://cdn.materialdesignicons.com/5.3.45/css/materialdesignicons.min.css">
-    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
-    <%= stylesheet_pack_tag 'application' %>
+    <%= javascript_pack_tag 'application', 'data-turbolinks-track': :reload %>
+    <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': :reload %>
     <%= favicon_link_tag(asset_pack_path("media/images/icon-36x36.png"), type: "image/png") %>
   </head>
 

--- a/app/views/playbooks/show.html.erb
+++ b/app/views/playbooks/show.html.erb
@@ -2,13 +2,17 @@
   <div class="column">
     <h1 class="title"><%= @playbook.name %></h1>
     <p class="is-italic"><%= @playbook.description %></p>
-    <div class="block">
-      <h4 class="subtitle" style="margin-top:1rem; margin-bottom:.5rem"><%= t('.ratings') %></h4>
-      <ul>
-        <% @playbook.ratings.each do |rating| %>
-          <li><%= display_rating(rating) %></li>
-        <% end %>
-      </ul>
+    <div class="card mt-1">
+      <header class="card-header">
+        <p class="card-header-title"><%= t('.ratings') %></p>
+      </header>
+      <div class="card-content">
+        <ul>
+          <% @playbook.ratings.each do |rating| %>
+            <li><%= display_rating(rating) %></li>
+          <% end %>
+        </ul>
+      </div>
     </div>
     <div class="block">
       <% if @playbook.luck_effect %>
@@ -24,17 +28,30 @@
   <div class="column">
     <h4 class="subtitle"><%= Gear.model_name.human(count: 3) %></h4>
     <%= render "gears/gears", gears: @playbook.gears %>
-    <h4 class="subtitle" style="margin-top:1rem; margin-bottom:.5rem"><%= Improvement.model_name.human(count: 3) %></h4>
-    <ul>
-      <% @playbook.improvements.not_advanced.each do |improvement| %>
-        <li><%= link_to_improvement(improvement) %></li>
-      <% end %>
-    </ul>
-    <h4 class="subtitle" style="margin-top:1rem; margin-bottom:.5rem"><%= t('.advanced_improvements') %></h4>
-    <ul>
-      <% @playbook.improvements.advanced.each do |improvement| %>
-        <li><%= link_to_improvement(improvement) %></li>
-      <% end %>
+    <div class="card  mt-2">
+      <header class="card-header">
+        <p class="card-header-title"><%= Improvement.model_name.human(count: 3) %></p>
+      </header>
+      <div class="card-content">
+        <ul>
+          <% @playbook.improvements.not_advanced.each do |improvement| %>
+            <li><%= link_to_improvement(improvement) %></li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+    <div class="card mt-2">
+      <header class="card-header">
+        <p class="card-header-title"><%= t('.advanced_improvements') %></p>
+      </header>
+      <div class="card-content">
+        <ul>
+          <% @playbook.improvements.advanced.each do |improvement| %>
+            <li><%= link_to_improvement(improvement) %></li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
     </ul>
     <div class="block content">
       <h4 class="subtitle"><%= @playbook.backstory&.name %></h4>


### PR DESCRIPTION
fixes #272

## Description of Changes
Reload stylesheet for Turbolinks, so the CSP allows it.

Also, remove inline styles and replace with cards, so the CSP stops complaining.

Did not fix: CSP complains on back button.

## Screenshots

## Problem Solved
CSP was throwing errors into the console due to inline styles and unreloaded stylesheets from turbolinks.

## PR Checklist
- [ ] Unit test coverage?
- [ ] Code Climate Passes? (Reach out to @ChaelCodes if checks need dismissing)
- [ ] Example Seed file if new data table introduced?
